### PR TITLE
Add new DiffDrive_C PTG capability to selfdriving

### DIFF
--- a/libselfdriving/include/selfdriving/ptgs/DiffDrive_C.h
+++ b/libselfdriving/include/selfdriving/ptgs/DiffDrive_C.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <mrpt/nav/tpspace/CPTG_DiffDrive_CollisionGridBased.h>
+#include <selfdriving/ptgs/SpeedTrimmablePTG.h>
 
 namespace selfdriving::ptg
 {
@@ -37,7 +38,8 @@ namespace selfdriving::ptg
  * \note [Before MRPT 1.5.0 this was named CPTG1]
  *  \ingroup nav_tpspace
  */
-class DiffDrive_C : public mrpt::nav::CPTG_DiffDrive_CollisionGridBased
+class DiffDrive_C : public mrpt::nav::CPTG_DiffDrive_CollisionGridBased,
+					public SpeedTrimmablePTG
 {
 	DEFINE_SERIALIZABLE(DiffDrive_C, selfdriving::ptg)
    public:

--- a/libselfdriving/include/selfdriving/ptgs/DiffDrive_C.h
+++ b/libselfdriving/include/selfdriving/ptgs/DiffDrive_C.h
@@ -1,0 +1,71 @@
+/* +------------------------------------------------------------------------+
+   |                     Mobile Robot Programming Toolkit (MRPT)            |
+   |                          https://www.mrpt.org/                         |
+   |                                                                        |
+   | Copyright (c) 2005-2023, Individual contributors, see AUTHORS file     |
+   | See: https://www.mrpt.org/Authors - All rights reserved.               |
+   | Released under BSD License. See: https://www.mrpt.org/License          |
+   +------------------------------------------------------------------------+ */
+#pragma once
+
+#include <mrpt/nav/tpspace/CPTG_DiffDrive_CollisionGridBased.h>
+
+namespace selfdriving::ptg
+{
+/** A PTG for circular paths ("C" type PTG in papers).
+ * - **Compatible kinematics**: differential-driven / Ackermann steering
+ * - **Compatible robot shape**: Arbitrary 2D polygon
+ * - **PTG parameters**: Use the app `ptg-configurator`
+ *
+ * This PT generator functions are:
+ *
+ * \f[ v(\alpha) = V_{MAX} sign(K) \f]
+ * \f[ \omega(\alpha) = \dfrac{\alpha}{\pi} W_{MAX} sign(K) \f]
+ *
+ * So, the radius of curvature of each trajectory is constant for each "alpha"
+ * value (the trajectory parameter):
+ *
+ *  \f[ R(\alpha) = \dfrac{v}{\omega} = \dfrac{V_{MAX}}{W_{MAX}}
+ * \dfrac{\pi}{\alpha} \f]
+ *
+ * from which a minimum radius of curvature can be set by selecting the
+ * appropriate values of V_MAX and W_MAX,
+ * knowning that \f$ \alpha \in (-\pi,\pi) \f$.
+ *
+ *  ![C-PTG path examples](PTG1_paths.png)
+ *
+ * \note [Before MRPT 1.5.0 this was named CPTG1]
+ *  \ingroup nav_tpspace
+ */
+class DiffDrive_C : public mrpt::nav::CPTG_DiffDrive_CollisionGridBased
+{
+	DEFINE_SERIALIZABLE(DiffDrive_C, selfdriving::ptg)
+   public:
+	DiffDrive_C() = default;
+	DiffDrive_C(
+		const mrpt::config::CConfigFileBase& cfg, const std::string& sSection)
+	{
+		loadFromConfigFile(cfg, sSection);
+	}
+	void loadFromConfigFile(
+		const mrpt::config::CConfigFileBase& cfg,
+		const std::string& sSection) override;
+	void saveToConfigFile(
+		mrpt::config::CConfigFileBase& cfg,
+		const std::string& sSection) const override;
+
+	std::string getDescription() const override;
+	bool inverseMap_WS2TP(
+		double x, double y, int& out_k, double& out_d,
+		double tolerance_dist = 0.10) const override;
+	bool PTG_IsIntoDomain(double x, double y) const override;
+	void ptgDiffDriveSteeringFunction(
+		float alpha, float t, float x, float y, float phi, float& v,
+		float& w) const override;
+	void loadDefaultParams() override;
+
+   protected:
+	/** A generation parameter */
+	double K{0};
+};
+}  // namespace selfdriving::ptg

--- a/libselfdriving/src/ptgs/DiffDrive_C.cpp
+++ b/libselfdriving/src/ptgs/DiffDrive_C.cpp
@@ -1,0 +1,155 @@
+/* +------------------------------------------------------------------------+
+   |                     Mobile Robot Programming Toolkit (MRPT)            |
+   |                          https://www.mrpt.org/                         |
+   |                                                                        |
+   | Copyright (c) 2005-2023, Individual contributors, see AUTHORS file     |
+   | See: https://www.mrpt.org/Authors - All rights reserved.               |
+   | Released under BSD License. See: https://www.mrpt.org/License          |
+   +------------------------------------------------------------------------+ */
+
+#include <mrpt/math/wrap2pi.h>
+#include <mrpt/serialization/CArchive.h>
+#include <selfdriving/ptgs/DiffDrive_C.h>
+
+using namespace mrpt;
+using namespace mrpt::nav;
+using namespace mrpt::system;
+using namespace selfdriving::ptg;
+
+IMPLEMENTS_SERIALIZABLE(
+	DiffDrive_C, mrpt::nav::CParameterizedTrajectoryGenerator, selfdriving::ptg)
+
+void DiffDrive_C::loadFromConfigFile(
+	const mrpt::config::CConfigFileBase& cfg, const std::string& sSection)
+{
+	CPTG_DiffDrive_CollisionGridBased::loadFromConfigFile(cfg, sSection);
+
+	MRPT_LOAD_CONFIG_VAR_NO_DEFAULT(K, double, cfg, sSection);
+}
+void DiffDrive_C::saveToConfigFile(
+	mrpt::config::CConfigFileBase& cfg, const std::string& sSection) const
+{
+	MRPT_START
+	const int WN = 25, WV = 30;
+	CPTG_DiffDrive_CollisionGridBased::saveToConfigFile(cfg, sSection);
+
+	cfg.write(
+		sSection, "K", K, WN, WV,
+		"K=+1 forward paths; K=-1 for backwards paths.");
+
+	MRPT_END
+}
+
+void DiffDrive_C::serializeFrom(
+	mrpt::serialization::CArchive& in, uint8_t version)
+{
+	CPTG_DiffDrive_CollisionGridBased::internal_readFromStream(in);
+
+	switch (version)
+	{
+		case 0: in >> K; break;
+		default: MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version);
+	};
+}
+
+uint8_t DiffDrive_C::serializeGetVersion() const { return 0; }
+void DiffDrive_C::serializeTo(mrpt::serialization::CArchive& out) const
+{
+	CPTG_DiffDrive_CollisionGridBased::internal_writeToStream(out);
+	out << K;
+}
+
+std::string DiffDrive_C::getDescription() const
+{
+	return mrpt::format("DiffDrive_C,K=%i", (int)K);
+}
+
+void DiffDrive_C::ptgDiffDriveSteeringFunction(
+	[[maybe_unused]] float alpha, [[maybe_unused]] float t,
+	[[maybe_unused]] float x, [[maybe_unused]] float y,
+	[[maybe_unused]] float phi, [[maybe_unused]] float& v,
+	[[maybe_unused]] float& w) const
+{
+	// (v,w)
+	v = V_MAX * sign(K);
+	// Use a linear mapping:  (Old was: w = tan( alpha/2 ) * W_MAX * sign(K))
+	w = (alpha / M_PI) * W_MAX * sign(K);
+}
+
+bool DiffDrive_C::PTG_IsIntoDomain(
+	[[maybe_unused]] double x, [[maybe_unused]] double y) const
+{
+	return true;
+}
+
+bool DiffDrive_C::inverseMap_WS2TP(
+	double x, double y, int& k_out, double& d_out,
+	[[maybe_unused]] double tolerance_dist) const
+{
+	bool is_exact = true;
+	if (y != 0)
+	{
+		double R = (x * x + y * y) / (2 * y);
+		const double Rmin = std::abs(V_MAX / W_MAX);
+
+		double theta;
+
+		if (K > 0)
+		{
+			if (y > 0) theta = atan2((double)x, fabs(R) - y);
+			else
+				theta = atan2((double)x, y + fabs(R));
+		}
+		else
+		{
+			if (y > 0) theta = atan2(-(double)x, fabs(R) - y);
+			else
+				theta = atan2(-(double)x, y + fabs(R));
+		}
+
+		// Arc length must be possitive [0,2*pi]
+		mrpt::math::wrapTo2PiInPlace(theta);
+
+		// Distance thru arc:
+		d_out = (float)(theta * (fabs(R) + turningRadiusReference));
+
+		if (std::abs(R) < Rmin)
+		{
+			is_exact = false;
+			R = Rmin * mrpt::sign(R);
+		}
+
+		// Was: a = 2*atan( V_MAX / (W_MAX*R) );
+		const double a = M_PI * V_MAX / (W_MAX * R);
+		k_out = alpha2index((float)a);
+	}
+	else
+	{
+		if (sign(x) == sign(K))
+		{
+			k_out = alpha2index(0);
+			d_out = x;
+			is_exact = true;
+		}
+		else
+		{
+			k_out = m_alphaValuesCount - 1;
+			d_out = 1e+3;
+			is_exact = false;
+		}
+	}
+
+	// Normalize:
+	d_out = d_out / refDistance;
+
+	ASSERT_GE_(k_out, 0);
+	ASSERT_LT_(k_out, m_alphaValuesCount);
+
+	return is_exact;
+}
+
+void DiffDrive_C::loadDefaultParams()
+{
+	CPTG_DiffDrive_CollisionGridBased::loadDefaultParams();
+	K = +1.0;
+}

--- a/libselfdriving/src/registerClasses.cpp
+++ b/libselfdriving/src/registerClasses.cpp
@@ -11,6 +11,7 @@
 #include <selfdriving/interfaces/TargetApproachController.h>
 #include <selfdriving/interfaces/VehicleMotionInterface.h>
 #include <selfdriving/ptgs/HolonomicBlend.h>
+#include <selfdriving/ptgs/DiffDrive_C.h>
 
 MRPT_INITIALIZER(selfdriving_register)
 {
@@ -32,4 +33,5 @@ MRPT_INITIALIZER(selfdriving_register)
 
     // PTGs:
     registerClass(CLASS_ID(ptg::HolonomicBlend));
+    registerClass(CLASS_ID(ptg::DiffDrive_C));
 }


### PR DESCRIPTION
Libselfdriving so far had only the HolonomicBlend PTG mainly for Holonomic Robots, but when applied to differential drive robots this PTG cannot be used. 

Hence adding the new differential drive ptg