### PR TITLE
fix: bind obs_xs/obs_ys by const ref in transform_pc_square_clipping

### DIFF
--- a/mrpt_path_planning/src/algos/transform_pc_square_clipping.cpp
+++ b/mrpt_path_planning/src/algos/transform_pc_square_clipping.cpp
@@ -11,8 +11,8 @@ void mpp::transform_pc_square_clipping(
     const double MAX_DIST_XY, mrpt::maps::CPointsMap& outMap,
     bool appendToOutMap)
 {
-    const auto   obs_xs = inMap.getPointsBufferRef_x();
-    const auto   obs_ys = inMap.getPointsBufferRef_y();
+    const auto&  obs_xs = inMap.getPointsBufferRef_x();
+    const auto&  obs_ys = inMap.getPointsBufferRef_y();
     const size_t nObs   = inMap.size();
 
     if (!appendToOutMap) { outMap.clear(); }

--- a/mrpt_path_planning/src/algos/transform_pc_square_clipping.cpp
+++ b/mrpt_path_planning/src/algos/transform_pc_square_clipping.cpp
@@ -11,6 +11,7 @@ void mpp::transform_pc_square_clipping(
     const double MAX_DIST_XY, mrpt::maps::CPointsMap& outMap,
     bool appendToOutMap)
 {
+    ASSERT_(&inMap != &outMap);  // inMap and outMap must be distinct objects
     const auto&  obs_xs = inMap.getPointsBufferRef_x();
     const auto&  obs_ys = inMap.getPointsBufferRef_y();
     const size_t nObs   = inMap.size();


### PR DESCRIPTION
getPointsBufferRef_x/y() return const std::vector<float>&, but were captured by value (const auto), causing a full O(N) copy on every call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal memory handling in path planning obstacle processing for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->