### PR TITLE
fix: store ptgTrimmableSpeed in best-path replacement block

### DIFF
--- a/mrpt_path_planning/src/algos/TPS_Astar.cpp
+++ b/mrpt_path_planning/src/algos/TPS_Astar.cpp
@@ -793,6 +793,11 @@ TPS_Astar::list_paths_to_neighbors_t
                 path.relTrgStep         = tpsPt.step;
                 path.neighborNodeCoords = nc;
                 path.ptgDynState        = ptg->getCurrentNavDynamicState();
+                // Must store the speed that was active during collision
+                // evaluation (applied via ptgTrimmable->trimmableSpeed_ above);
+                // without this, ptgTrimmableSpeed keeps its default of 1.0 and
+                // the trimmed speed used to win this best-path slot is lost.
+                path.ptgTrimmableSpeed  = tpsPt.speed;
             }
         }
 

--- a/tests/test_astar_holonomic.cpp
+++ b/tests/test_astar_holonomic.cpp
@@ -167,3 +167,31 @@ TEST(AstarHolonomic, PathCostIsPositive)
     EXPECT_GT(out.pathCost, 0.0)
         << "Path cost must be positive for a non-trivial path";
 }
+
+TEST(AstarHolonomic, TrimSpeedPreservedInBestPath)
+{
+    // Use max_ptg_speeds_to_explore >= 2 so the planner evaluates a reduced
+    // speed level. If a lower-speed path wins, ptgTrimmableSpeed must reflect
+    // that speed rather than the default 1.0.
+    auto planner                              = buildPlanner();
+    planner.params_.max_ptg_speeds_to_explore = 3;
+
+    auto in  = buildInput(/*gx=*/3.0, /*gy=*/0.0);
+    auto out = planner.plan(in);
+
+    ASSERT_TRUE(out.success);
+
+    // Walk all edges in the motion tree; at least one must have a trimmed
+    // speed < 1.0 (the planner explored non-maximum speeds).
+    bool found_trimmed = false;
+    for (const auto& kv : out.motionTree.edges_to_children)
+    {
+        for (const auto& edge : kv.second)
+        {
+            if (edge.data.ptgTrimmableSpeed < 0.999) found_trimmed = true;
+        }
+    }
+
+    EXPECT_TRUE(found_trimmed)
+        << "No edge has ptgTrimmableSpeed < 1.0; speed is being lost";
+}


### PR DESCRIPTION
When a shorter path replaced an existing bestPaths entry, all fields were updated except ptgTrimmableSpeed, which silently kept its default of 1.0. The speed applied to the PTG during collision evaluation was therefore lost on every replacement.

Add path.ptgTrimmableSpeed = tpsPt.speed in the if (relTrgDist < path.ptgDist) block alongside all other path.* assignments.

Add TrimSpeedPreservedInBestPath test: runs the planner with max_ptg_speeds_to_explore=3 and asserts that at least one edge in the output tree carries ptgTrimmableSpeed < 1.0.