### PR TITLE
fix: restore A* admissibility by converting heuristic to seconds

### DIFF
--- a/mrpt_path_planning/include/mpp/algos/TPS_Astar.h
+++ b/mrpt_path_planning/include/mpp/algos/TPS_Astar.h
@@ -330,6 +330,13 @@ class TPS_Astar : virtual public mrpt::system::COutputLogger, public Planner
         const mrpt::math::TPose2D&                      queryPose,
         const std::vector<mrpt::maps::CPointsMap::Ptr>& globalObstacles,
         double                                          MAX_PTG_XY_DIST);
+
+    /** Maximum linear speed across all active PTGs, cached at the start of
+     *  each plan() call. Used to convert geometric distances (meters) to
+     *  time estimates (seconds) in the heuristic, ensuring admissibility when
+     *  edge costs are in seconds (estimatedExecTime). Defaults to 1.0 so
+     *  that heuristic calls outside plan() return geometric distances. */
+    double maxLinSpeed_ = 1.0;
 };
 
 }  // namespace mpp

--- a/mrpt_path_planning/src/algos/TPS_Astar.cpp
+++ b/mrpt_path_planning/src/algos/TPS_Astar.cpp
@@ -120,6 +120,12 @@ PlannerOutput TPS_Astar::plan(const PlannerInput& in)
         mrpt::keep_max(MAX_XY_DIST, ptg->getRefDistance());
     ASSERT_(MAX_XY_DIST > 0);
 
+    // Cache max linear speed for heuristic unit conversion (distance→time).
+    maxLinSpeed_ = 0.0;
+    for (const auto& ptg : in.ptgs.ptgs)
+        mrpt::keep_max(maxLinSpeed_, ptg->getMaxLinVel());
+    if (maxLinSpeed_ <= 0) maxLinSpeed_ = 1.0;  // fallback: units = distance
+
     // obstacles (TODO: dynamic over future time?):
     std::vector<mrpt::maps::CPointsMap::Ptr> obstaclePoints;
     for (const auto& os : in.obstacles)
@@ -501,14 +507,15 @@ cost_t TPS_Astar::default_heuristic_SE2(
                   mrpt::math::angDistance(
                       std::atan2(relPose.y, relPose.x), from.pose.phi));
 
-    return distSE2 + params_.heuristic_heading_weight * distHeading;
+    return (distSE2 + params_.heuristic_heading_weight * distHeading) /
+           maxLinSpeed_;
 }
 
 cost_t TPS_Astar::default_heuristic_R2(
     const SE2_KinState& from, const mrpt::math::TPoint2D& goal) const
 {
     // Distance in R^2 only — heading is irrelevant for R(2) goals.
-    return (from.pose.translation() - goal).norm();
+    return (from.pose.translation() - goal).norm() / maxLinSpeed_;
 }
 
 TPS_Astar::Node& TPS_Astar::getOrCreateNodeByPose(

--- a/tests/test_heuristic.cpp
+++ b/tests/test_heuristic.cpp
@@ -16,7 +16,11 @@
 
 #include <gtest/gtest.h>
 #include <mpp/algos/TPS_Astar.h>
+#include <mpp/data/PlannerInput.h>
+#include <mpp/interfaces/ObstacleSource.h>
+#include <mrpt/config/CConfigFileMemory.h>
 #include <mrpt/core/bits_math.h>  // _deg
+#include <mrpt/maps/CSimplePointsMap.h>
 
 using namespace mrpt::literals;  // for _deg
 
@@ -131,4 +135,105 @@ TEST(Heuristic, SE2IncludesHeadingCost)
         planner.default_heuristic(makeState(0, 0, 180), goal);
 
     EXPECT_GT(hOpposite, hAligned);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers for integration-level heuristic tests (require a PTG set).
+// ---------------------------------------------------------------------------
+static const char* kPtgCfg = R"cfg(
+[SelfDriving]
+min_obstacles_height  = 0.0
+max_obstacles_height  = 2.0
+
+PTG_COUNT = 1
+
+PTG0_Type        = mpp::ptg::HolonomicBlend
+PTG0_refDistance = 5.0
+PTG0_num_paths   = 61
+PTG0_T_ramp_max  = 1.0
+PTG0_v_max_mps   = 1.0
+PTG0_w_max_dps   = 60.0
+PTG0_expr_V      = V_MAX * trimmable_speed
+PTG0_expr_W      = W_MAX * trimmable_speed * min(1.0, 0.1+abs(dir)/(10*3.14159265/180))
+PTG0_expr_T_ramp = T_ramp_max
+
+RobotModel_circular_shape_radius = 0.15
+)cfg";
+
+static mpp::PlannerInput buildInput(double gx, double gy)
+{
+    mrpt::config::CConfigFileMemory cfg(kPtgCfg);
+    mpp::PlannerInput               in;
+    in.ptgs.initFromConfigFile(cfg, "SelfDriving");
+    in.stateStart.pose  = {0, 0, 0};
+    in.stateGoal.state  = mrpt::math::TPoint2D{gx, gy};
+    in.worldBboxMin     = {-6, -6, -M_PI};
+    in.worldBboxMax     = {6, 6, M_PI};
+    return in;
+}
+
+static mpp::TPS_Astar buildPlanner()
+{
+    mpp::TPS_Astar planner;
+    planner.setMinLoggingLevel(mrpt::system::LVL_ERROR);
+    planner.params_.grid_resolution_xy              = 0.20;
+    planner.params_.grid_resolution_yaw             = 10.0 * M_PI / 180.0;
+    planner.params_.max_ptg_trajectories_to_explore = 15;
+    planner.params_.ptg_sample_timestamps           = {0.5, 1.5, 3.0};
+    planner.params_.max_ptg_speeds_to_explore       = 1;
+    planner.params_.maximumComputationTime          = 30.0;
+    planner.params_.SE2_metricAngleWeight           = 0.1;
+    planner.params_.heuristic_heading_weight        = 0.1;
+    return planner;
+}
+
+// ---------------------------------------------------------------------------
+
+TEST(Heuristic, ZeroAtGoalAfterPlan)
+{
+    // After plan() initialises maxLinSpeed_, h(goal, goal) must still be 0.
+    auto planner = buildPlanner();
+    auto in      = buildInput(/*gx=*/2.0, /*gy=*/0.0);
+
+    const auto out = planner.plan(in);
+    ASSERT_TRUE(out.success);
+
+    const auto goalState = makeState(2.0, 0.0, 0.0);
+    const auto goalR2    = mrpt::math::TPoint2D{2.0, 0.0};
+    EXPECT_NEAR(planner.default_heuristic_R2(goalState, goalR2), 0.0, 1e-9);
+}
+
+TEST(Heuristic, ConsistencyAlongPlanEdges)
+{
+    // For every edge u→v in the output motion tree:
+    //   h(u) <= cost(u,v) + h(v)   (A* consistency / monotonicity)
+    auto planner = buildPlanner();
+    auto in      = buildInput(/*gx=*/3.0, /*gy=*/2.0);
+
+    const auto out = planner.plan(in);
+    ASSERT_TRUE(out.success);
+
+    const mrpt::math::TPoint2D goalPt{3.0, 2.0};
+    int                        edgeCount = 0;
+
+    for (const auto& kv : out.motionTree.edges_to_children)
+    {
+        for (const auto& edgeEntry : kv.second)
+        {
+            const auto& e = edgeEntry.data;
+
+            const double h_from =
+                planner.default_heuristic_R2(e.stateFrom, goalPt);
+            const double h_to =
+                planner.default_heuristic_R2(e.stateTo, goalPt);
+            const double edge_cost = planner.cost_path_segment(e);
+
+            EXPECT_LE(h_from, edge_cost + h_to + 1e-6)
+                << "Heuristic violates consistency: h(u)=" << h_from
+                << " > cost(u,v)+h(v)=" << edge_cost + h_to;
+            ++edgeCount;
+        }
+    }
+
+    EXPECT_GT(edgeCount, 0) << "No edges found in motion tree";
 }


### PR DESCRIPTION
default_heuristic_SE2 and default_heuristic_R2 returned geometric distances (meters) while edge costs use estimatedExecTime (seconds). When the robot travels faster than 1 m/s the heuristic could exceed the true cost-to-goal, breaking the optimality guarantee.

Fix: cache max(ptg->getMaxLinVel()) over all active PTGs in maxLinSpeed_ at the start of plan(), then divide both heuristic
return values by it. Falls back to 1.0 if no PTG reports a positive speed, preserving the previous distance-based behaviour.

Add two tests to test_heuristic.cpp:
- ZeroAtGoalAfterPlan: h(goal) == 0 after plan() sets maxLinSpeed_.
- ConsistencyAlongPlanEdges: verifies h(u) <= cost(u,v) + h(v) for every edge in the output motion tree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path planning heuristic calculations to account for robot velocity, enhancing plan optimization efficiency.

* **Tests**
  * Added integration tests validating heuristic consistency and monotonic behavior in path planning operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->