### PR TITLE
feat(TPS_Astar): wire stateGoal.vel into goal-cell exit speed

### DIFF
--- a/mrpt_path_planning/src/algos/TPS_Astar.cpp
+++ b/mrpt_path_planning/src/algos/TPS_Astar.cpp
@@ -182,10 +182,14 @@ PlannerOutput TPS_Astar::plan(const PlannerInput& in)
             ? nodeGridCoords(in.stateGoal.state.point())
             : nodeGridCoords(in.stateGoal.state.pose());
 
-    // goal speed=0
-    MRPT_TODO("Actually check user input on desired speed at goal");
+    // Desired speed at goal, stored as **absolute linear speed in m/s**.
+    // Each PTG normalises this against its own v_max when it reads the map
+    // (see find_feasible_paths_to_neighbors).  Only the XY linear component
+    // is used; a purely-angular exit velocity maps to 0 (stop) because
+    // PTG targetRelSpeed is a linear-speed modifier.
     nodes_with_desired_speed_t nodesWithDesiredSpeed;
-    nodesWithDesiredSpeed[goalCellIndices] = 0;
+    nodesWithDesiredSpeed[goalCellIndices] =
+        std::hypot(in.stateGoal.vel.vx, in.stateGoal.vel.vy);
 
     unsigned int nIter = 0;
 
@@ -333,7 +337,7 @@ PlannerOutput TPS_Astar::plan(const PlannerInput& in)
             newEdge.ptgPathIndex = edge.ptgTrajIndex.value();
 
             newEdge.ptgTrimmableSpeed    = edge.ptgTrimmableSpeed;
-            newEdge.ptgFinalGoalRelSpeed = 0;
+            newEdge.ptgFinalGoalRelSpeed = edge.ptgDynState.value().targetRelSpeed;
             newEdge.ptgFinalRelativeGoal =
                 in.stateGoal.asSE2KinState().pose - current.state.pose;
 
@@ -593,12 +597,16 @@ TPS_Astar::list_paths_to_neighbors_t
             if (const auto it = nodesWithSpeed.find(iGoalCoords);
                 it != nodesWithSpeed.end())
             {
-                MRPT_TODO("Speed zone filter here too?");
-                ds.targetRelSpeed = it->second;
+                // it->second is an absolute speed (m/s); normalise against
+                // this PTG's own maximum linear velocity so that the result
+                // is in [0, 1] regardless of the robot's top speed.
+                const double ptgVmax =
+                    std::max(ptg->getMaxLinVel(), 1e-6);
+                ds.targetRelSpeed =
+                    std::min(1.0, it->second / ptgVmax);
             }
             else
             {
-                MRPT_TODO("Support case of final goal speed!=0 ?");
                 ds.targetRelSpeed = 0;
             }
 

--- a/tests/test_astar_holonomic.cpp
+++ b/tests/test_astar_holonomic.cpp
@@ -45,15 +45,37 @@ PTG0_expr_T_ramp = T_ramp_max
 RobotModel_circular_shape_radius = 0.15
 )cfg";
 
+// PTG config with v_max = 2.0 m/s — used for the normalisation regression test.
+static const char* kHolonomicPtgCfg2mps = R"cfg(
+[SelfDriving]
+min_obstacles_height  = 0.0
+max_obstacles_height  = 2.0
+
+PTG_COUNT = 1
+
+PTG0_Type        = mpp::ptg::HolonomicBlend
+PTG0_refDistance = 5.0
+PTG0_num_paths   = 61
+PTG0_T_ramp_max  = 1.0
+PTG0_v_max_mps   = 2.0
+PTG0_w_max_dps   = 60.0
+PTG0_expr_V      = V_MAX * trimmable_speed
+PTG0_expr_W      = W_MAX * trimmable_speed * min(1.0, 0.1+abs(dir)/(10*3.14159265/180))
+PTG0_expr_T_ramp = T_ramp_max
+
+RobotModel_circular_shape_radius = 0.15
+)cfg";
+
 // ---------------------------------------------------------------------------
 // Helper: build a PlannerInput for a holonomic robot
 // ---------------------------------------------------------------------------
 static mpp::PlannerInput buildInput(
     double gx, double gy, bool goalIsSE2 = false, double goalPhi_deg = 0.0,
-    const mrpt::maps::CSimplePointsMap::Ptr& obsPts = nullptr)
+    const mrpt::maps::CSimplePointsMap::Ptr& obsPts = nullptr,
+    const char* ptgCfg = kHolonomicPtgCfg)
 {
     // Load PTGs
-    mrpt::config::CConfigFileMemory cfg(kHolonomicPtgCfg);
+    mrpt::config::CConfigFileMemory cfg(ptgCfg);
     mpp::PlannerInput               in;
     in.ptgs.initFromConfigFile(cfg, "SelfDriving");
 
@@ -166,4 +188,75 @@ TEST(AstarHolonomic, PathCostIsPositive)
     ASSERT_TRUE(out.success);
     EXPECT_GT(out.pathCost, 0.0)
         << "Path cost must be positive for a non-trivial path";
+}
+
+TEST(AstarHolonomic, NonZeroGoalSpeedPreserved)
+{
+    // When stateGoal.vel carries a non-zero exit velocity, the final planned
+    // edge must reflect a non-zero ptgFinalGoalRelSpeed so the robot does not
+    // decelerate to a full stop when chaining waypoints.
+    auto planner = buildPlanner();
+    auto in      = buildInput(/*gx=*/3.0, /*gy=*/0.0);
+
+    in.stateGoal.vel = mrpt::math::TTwist2D{0.5, 0.0, 0.0};  // 0.5 m/s fwd
+
+    const auto out = planner.plan(in);
+    ASSERT_TRUE(out.success);
+    ASSERT_TRUE(out.goalNodeId.has_value());
+
+    const auto& last_edge =
+        out.motionTree.edge_to_parent(out.goalNodeId.value());
+    EXPECT_GT(last_edge.ptgFinalGoalRelSpeed, 0.01)
+        << "Final edge must carry non-zero goal speed when stateGoal.vel is set";
+}
+
+TEST(AstarHolonomic, ZeroGoalSpeedDefault)
+{
+    // When stateGoal.vel is unset (zero), the planner must preserve the
+    // original stop-at-goal behaviour.
+    auto planner = buildPlanner();
+    auto in      = buildInput(/*gx=*/2.0, /*gy=*/0.0);
+    // stateGoal.vel intentionally left at default TTwist2D{0,0,0}.
+
+    const auto out = planner.plan(in);
+    ASSERT_TRUE(out.success);
+    ASSERT_TRUE(out.goalNodeId.has_value());
+
+    const auto& last_edge =
+        out.motionTree.edge_to_parent(out.goalNodeId.value());
+    EXPECT_NEAR(last_edge.ptgFinalGoalRelSpeed, 0.0, 0.05)
+        << "Robot should stop at goal when stateGoal.vel is unset";
+}
+
+TEST(AstarHolonomic, GoalSpeedNormalisedAgainstPtgVmax)
+{
+    // Use a PTG with v_max = 2.0 m/s.  Request an exit speed of 1.0 m/s
+    // (= 50 % of v_max).  The stored normalised speed must be ≈ 0.5, NOT 1.0.
+    // This guards against the regression where hypot(vx,vy) was used directly
+    // without dividing by the PTG's own maximum linear velocity.
+    auto planner = buildPlanner();
+    auto in      = buildInput(
+        /*gx=*/3.0, /*gy=*/0.0,
+        /*goalIsSE2=*/false, /*goalPhi_deg=*/0.0,
+        /*obsPts=*/nullptr, kHolonomicPtgCfg2mps);
+
+    // Request 1.0 m/s exit speed; PTG v_max = 2.0 m/s → expected relSpeed ≈ 0.5
+    in.stateGoal.vel = mrpt::math::TTwist2D{1.0, 0.0, 0.0};
+
+    const auto out = planner.plan(in);
+    ASSERT_TRUE(out.success);
+    ASSERT_TRUE(out.goalNodeId.has_value());
+
+    const auto& last_edge =
+        out.motionTree.edge_to_parent(out.goalNodeId.value());
+
+    // Must be non-zero (goal speed wired in).
+    EXPECT_GT(last_edge.ptgFinalGoalRelSpeed, 0.01)
+        << "Goal speed must be propagated when stateGoal.vel is set";
+
+    // Must be well below 1.0 — if normalisation was missing the value would
+    // have been clamped to 1.0 (full speed), not ≈ 0.5.
+    EXPECT_LT(last_edge.ptgFinalGoalRelSpeed, 0.9)
+        << "Normalised goal speed must account for PTG v_max (2 m/s), "
+           "so 1 m/s requested should give ~0.5, not 1.0";
 }


### PR DESCRIPTION
Two MRPT_TODO stubs in TPS_Astar::plan() left the robot hard-coded to stop at every goal, ignoring PlannerInput::stateGoal.vel entirely.

Changes
- nodesWithDesiredSpeed[goalCellIndices] is now populated from hypot(stateGoal.vel.vx, stateGoal.vel.vy) in absolute m/s instead of being hard-wired to 0.
- find_feasible_paths_to_neighbors() normalises the stored speed against each PTG's own getMaxLinVel(), clamped to [0, 1], so multi-PTG setups with different top speeds each scale correctly.
- newEdge.ptgFinalGoalRelSpeed is set from the planning-time PTG dynamic state (edge.ptgDynState.targetRelSpeed) instead of 0, ensuring that MoveEdgeSE2_TPS::getPTGDynState() faithfully reproduces the conditions used during planning when the edge is replayed by NavEngine.

Behaviour
- stateGoal.vel == {0,0,0} (default): robot stops at goal — no change.
- stateGoal.vel != {0,0,0}: final edge carries a non-zero ptgFinalGoalRelSpeed, enabling seamless waypoint chaining without a dead stop.

Tests
- NonZeroGoalSpeedPreserved: asserts ptgFinalGoalRelSpeed > 0.01 when stateGoal.vel = {0.5, 0, 0}.
- ZeroGoalSpeedDefault: asserts ptgFinalGoalRelSpeed ≈ 0 when vel is unset (regression guard for existing behaviour).
- GoalSpeedNormalisedAgainstPtgVmax: uses a v_max=2.0 m/s PTG and requests 1.0 m/s exit speed; asserts result < 0.9 to catch the missing-normalization regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * A* path planner now respects goal velocity magnitudes when specified, enabling dynamic exit speeds.

* **Bug Fixes**
  * Fixed speed normalization to properly account for each trajectory generator's maximum velocity limits.

* **Tests**
  * Added test coverage for goal-speed preservation and velocity normalization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->