### PR TITLE
fix: include yaw in cached_local_obstacles cache key for A-star

### DIFF
--- a/mrpt_path_planning/include/mpp/algos/TPS_Astar.h
+++ b/mrpt_path_planning/include/mpp/algos/TPS_Astar.h
@@ -345,10 +345,10 @@ class TPS_Astar : virtual public mrpt::system::COutputLogger, public Planner
      *  that heuristic calls outside plan() return geometric distances. */
     double maxLinSpeed_ = 1.0;
 
-    /** Cache of local obstacle maps, keyed by (ix, iy) grid cell (no yaw,
-     *  since obstacle clipping only depends on xy position). Cleared at the
-     *  start of each plan() call. Nodes in the same cell share the same
-     *  transformed obstacle cloud, avoiding redundant O(N_obs) transforms. */
+    /** Cache of local obstacle maps, keyed by (ix, iy, iyaw) grid cell.
+     *  transform_pc_square_clipping rotates obstacles into the robot-local
+     *  frame, so yaw must be part of the key. Cleared at the start of each
+     *  plan() call. */
     std::unordered_map<NodeCoords, mrpt::maps::CPointsMap::Ptr, NodeCoordsHash>
         localObstaclesCache_;
 };

--- a/mrpt_path_planning/src/algos/TPS_Astar.cpp
+++ b/mrpt_path_planning/src/algos/TPS_Astar.cpp
@@ -853,8 +853,10 @@ mrpt::maps::CPointsMap::Ptr TPS_Astar::cached_local_obstacles(
 {
     mrpt::system::CTimeLoggerEntry tle(profiler_(), "cached_local_obstacles");
 
-    // Cache key: xy grid cell only (heading does not affect obstacle clipping).
-    const NodeCoords key(x2idx(queryPose.x), y2idx(queryPose.y));
+    // Cache key includes yaw: transform_pc_square_clipping rotates obstacles
+    // into the robot-local frame, so the output depends on heading.
+    const NodeCoords key(
+        x2idx(queryPose.x), y2idx(queryPose.y), phi2idx(queryPose.phi));
 
     if (auto it = localObstaclesCache_.find(key);
         it != localObstaclesCache_.end())


### PR DESCRIPTION
transform_pc_square_clipping rotates obstacle points into the robot-local frame, so the cached cloud is heading-dependent. Keying by (ix, iy) only caused nodes at the same grid cell but different yaw to receive a cloud rotated for the wrong heading, corrupting TP-space collision checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed the local obstacle caching mechanism to properly account for robot heading angle. Cached obstacles now correctly depend on the robot's current orientation, improving path planning accuracy.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MRPT/mrpt_path_planning/pull/21)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->