### PR TITLE
perf(TPS_Astar): batch TP-obstacle collision check per expansion

### DIFF
--- a/mrpt_path_planning/src/algos/TPS_Astar.cpp
+++ b/mrpt_path_planning/src/algos/TPS_Astar.cpp
@@ -943,6 +943,31 @@ TPS_Astar::list_paths_to_neighbors_t
 
         std::unordered_set<NodeCoords, NodeCoordsHash> goalNodeCoords;
 
+        // Build the full TP-obstacle free-distance array ONCE for this PTG at
+        // this node, in a single pass over the local obstacle cloud:
+        // updateTPObstacle() fills the collision-free distance for ALL
+        // trajectory directions `k` per obstacle point (one collision-grid
+        // lookup yields all k). This replaces the former pattern of re-scanning
+        // the whole cloud once per candidate trajectory, which was the dominant
+        // planner cost (O(candidates x N_points) -> O(N_points)). The collision
+        // grid is purely geometric, so the result is independent of the
+        // trimmable speed and of the timestamp, and can be shared by all
+        // candidates of this PTG.
+        std::vector<double> tpObstacles;
+        {
+            mrpt::system::CTimeLoggerEntry tleObsAll(
+                profiler_(), "find_feasible.tp_obstacles_all");
+
+            ptg->initTPObstacles(tpObstacles);
+            const auto&  ox   = localObstacles->getPointsBufferRef_x();
+            const auto&  oy   = localObstacles->getPointsBufferRef_y();
+            const size_t nObs = localObstacles->size();
+            for (size_t i = 0; i < nObs; i++)
+            {
+                ptg->updateTPObstacle(ox[i], oy[i], tpObstacles);
+            }
+        }
+
         // now, check which ones of those paths are not blocked by
         // obstacles:
         for (size_t tpsPtIdx = 0; tpsPtIdx < tpsPointsToConsider.size();
@@ -977,14 +1002,9 @@ TPS_Astar::list_paths_to_neighbors_t
 
             const NodeCoords nc = nodeGridCoords(absPose);
 
-            mrpt::system::CTimeLoggerEntry tleObs(
-                profiler_(), "find_feasible.tp_obstacles_single");
-
-            // check for collisions:
-            const distance_t freeDistance =
-                tp_obstacles_single_path(tpsPt.k, *localObstacles, *ptg);
-
-            tleObs.stop();
+            // check for collisions: read the precomputed free distance for
+            // this trajectory direction (built once above for all candidates).
+            const distance_t freeDistance = tpObstacles[tpsPt.k];
 
             if (relTrgDist >= freeDistance)
             {


### PR DESCRIPTION
## What
`find_feasible_paths_to_neighbors` called `tp_obstacles_single_path` **once per candidate trajectory**, each re-scanning the whole local obstacle cloud: O(candidates x N_points) per expansion. Now it builds the full TP-obstacle free-distance array **once per node** via `PTG::updateTPObstacle()` (one collision-grid lookup fills all directions `k`), then reads `tpObstacles[k]` per candidate: **O(N_points)**.

## Why
Profiling TPS-A* (the planning bottleneck vs Nav2): collision checking was **45-63% of plan()** time (~38k `tp_obstacles_single` calls on a hard BARN world).

## Result (matched diff-drive, BARN, planning-only)
**Behavior-preserving** (free distances identical; solution paths unchanged — verified by end-to-end tests and identical solution-edge counts), **~2-3x faster**:
| world | before | after |
|---|---|---|
| 100 | 152 ms | 68 ms |
| 299 | 316 ms | 110 ms |
| 200 | 17.6 ms | 5.6 ms |

Collision-check time on world 100: 95.9 ms -> 12.9 ms (7.4x).

## Tests
22/22 ctest pass (existing end-to-end planning tests guard the behavior-equivalence). Pure optimization, always on, no new params.