### PR TITLE
perf(TPS_Astar): defer per-edge path interpolation to the final solution

### DIFF
--- a/mrpt_path_planning/include/mpp/data/MoveEdgeSE2_TPS.h
+++ b/mrpt_path_planning/include/mpp/data/MoveEdgeSE2_TPS.h
@@ -42,6 +42,11 @@ struct MoveEdgeSE2_TPS
      * motion segment (NOT normalized distances) */
     distance_t ptgDist = std::numeric_limits<distance_t>::max();
 
+    /** Trajectory step index at the end of this segment. Stored so the
+     * interpolated path can be (re)built lazily, e.g. only for the final
+     * solution edges when interpolation is deferred during the A* search. */
+    uint32_t ptgStepIndex = 0;
+
     normalized_speed_t ptgTrimmableSpeed = 1.0;
 
     mrpt::math::TPose2D ptgFinalRelativeGoal;

--- a/mrpt_path_planning/src/algos/TPS_Astar.cpp
+++ b/mrpt_path_planning/src/algos/TPS_Astar.cpp
@@ -228,6 +228,16 @@ PlannerOutput TPS_Astar::plan(const PlannerInput& in)
 
     double tLastCallback = planInitTime;
 
+    // Defer building per-edge interpolated paths during the search: it is a
+    // major cost (a std::map per edge) and is only needed for (a) cost
+    // evaluators that score edges, (b) debug visualization, or (c) progress
+    // callbacks that inspect the partial path. When none of these apply, we
+    // store only estimatedExecTime during the search and interpolate just the
+    // final solution edges at the end.
+    const bool deferInterpolation =
+        costEvaluators_.empty() &&
+        params_.saveDebugVisualizationDecimation == 0 && !progressCallback_;
+
     while (!openSet.empty())
     {
         mrpt::system::CTimeLoggerEntry tle(profiler_(), "plan.iter");
@@ -384,13 +394,24 @@ PlannerOutput TPS_Astar::plan(const PlannerInput& in)
             newEdge.ptgInternalState =
                 ptg.getCurrentNavDynamicState().internalState;
 #endif
-            newEdge.stateFrom = current.state;
-            newEdge.stateTo   = x_i;
+            newEdge.stateFrom    = current.state;
+            newEdge.stateTo      = x_i;
+            newEdge.ptgStepIndex = ptg_step;
 
-            // interpolated path:
-            edge_interpolated_path(
-                newEdge, in.ptgs, reconstrRelPose, ptg_step,
-                params_.pathInterpolatedSegments);
+            // interpolated path (deferred to the final solution when possible,
+            // see `deferInterpolation`): otherwise set the cheap exec-time
+            // only.
+            if (deferInterpolation)
+            {
+                newEdge.estimatedExecTime =
+                    ptg_step * ptg.getPathStepDuration();
+            }
+            else
+            {
+                edge_interpolated_path(
+                    newEdge, in.ptgs, reconstrRelPose, ptg_step,
+                    params_.pathInterpolatedSegments);
+            }
 
             // Let's compute its cost:
             newEdge.cost = cost_path_segment(newEdge);
@@ -537,6 +558,25 @@ PlannerOutput TPS_Astar::plan(const PlannerInput& in)
         }
 
     }  // end while openSet!=empty
+
+    // If interpolation was deferred during the search, build it now for just
+    // the final solution-path edges (needed for output / refinement / exec).
+    if (deferInterpolation && po.bestNodeId.has_value() &&
+        po.goalNodeId == po.bestNodeId)
+    {
+        const auto [solNodes, solEdges] =
+            tree.backtrack_path(po.bestNodeId.value());
+        for (auto* e : solEdges)
+        {
+            if (e == nullptr) { continue; }
+            // Recover the relative reconstruction pose (stateTo in the frame
+            // of stateFrom); identical to what was used during the search.
+            const auto reconstrRelPose = e->stateTo.pose - e->stateFrom.pose;
+            edge_interpolated_path(
+                *e, in.ptgs, reconstrRelPose, e->ptgStepIndex,
+                params_.pathInterpolatedSegments);
+        }
+    }
 
     // A* ended, now collect the result:
     // ----------------------------------------


### PR DESCRIPTION
## What
During the A* search, skip building each candidate edge's interpolated path (a `std::map<time,pose>`); set only the scalar `estimatedExecTime = ptg_step * dt` (all the cost needs when there are no cost evaluators). Build interpolated paths only for the final **solution** edges at the end. Inspired by Nav2 Smac (interpolation/smoothing deferred to the final path).

## Safety
Deferral applies only when it cannot change results: no cost evaluators (they score edges via the interpolated path), no debug viz, no progress callback (inspects the partial path). Otherwise the previous inline interpolation is used. New `MoveEdgeSE2_TPS::ptgStepIndex` stores the step for post-search re-interpolation.

## Result
Behavior-preserving (identical solution paths/edge counts; verified by end-to-end tests + saved interpolated-path inspection). Measured **~17-21% faster** `plan()` when active: world 100 68->54 ms, world 299 110->92 ms.

## Context
This is the new top cost after #26 (batched collision). Profiling story in the paper's DESIGN.md section 12.4.

22/22 ctest pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Deferred path interpolation computation in planning algorithm to occur post-search for final solution paths instead of during search.
  * Added step index tracking to path segments to support lazy interpolation rebuilding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->