### PR TITLE
fix(TPS_Astar): obstacle cache ignored heading -> collision false negatives

### DIFF
--- a/mrpt_path_planning/src/algos/TPS_Astar.cpp
+++ b/mrpt_path_planning/src/algos/TPS_Astar.cpp
@@ -16,6 +16,7 @@
 #include <mrpt/opengl/COpenGLScene.h>
 #include <mrpt/version.h>
 
+#include <cmath>
 #include <iostream>
 #include <queue>
 #include <unordered_set>
@@ -1137,22 +1138,62 @@ mrpt::maps::CPointsMap::Ptr TPS_Astar::cached_local_obstacles(
 {
     mrpt::system::CTimeLoggerEntry tle(profiler_(), "cached_local_obstacles");
 
-    // Cache key: xy grid cell only (heading does not affect obstacle clipping).
+    // Only the *clipping* of the global obstacle set to a local window depends
+    // solely on the xy cell, so that (expensive, O(N_global)) step is cached
+    // per (ix,iy). The subsequent rigid transform into the robot-local frame
+    // DEPENDS ON HEADING and must NOT be cached across headings: doing so
+    // (former behavior, keyed by xy only) reused obstacles rotated for a
+    // different heading, yielding collision FALSE NEGATIVES (the planner could
+    // tunnel through walls). So we transform the small clipped subset per call.
     const NodeCoords key(x2idx(queryPose.x), y2idx(queryPose.y));
 
+    mrpt::maps::CPointsMap::Ptr clippedGlobal;
     if (auto it = localObstaclesCache_.find(key);
         it != localObstaclesCache_.end())
-        return it->second;
-
-    auto outObs = mrpt::maps::CSimplePointsMap::Create();
-
-    for (const auto& obs : globalObstacles)
     {
-        ASSERT_(obs);
-        transform_pc_square_clipping(
-            *obs, mrpt::poses::CPose2D(queryPose), MAX_PTG_XY_DIST, *outObs);
+        clippedGlobal = it->second;
+    }
+    else
+    {
+        // Clip (keeping GLOBAL coordinates) to a square around the cell center,
+        // enlarged by half a cell so the cached subset is a valid superset for
+        // any exact pose falling in this cell.
+        const double res = params_.grid_resolution_xy;
+        const double cx  = key.idxX * res;
+        const double cy  = key.idxY * res;
+        const double win = MAX_PTG_XY_DIST + 0.5 * res;
+
+        clippedGlobal = mrpt::maps::CSimplePointsMap::Create();
+        for (const auto& obs : globalObstacles)
+        {
+            ASSERT_(obs);
+            const auto&  xs = obs->getPointsBufferRef_x();
+            const auto&  ys = obs->getPointsBufferRef_y();
+            const size_t n  = obs->size();
+            for (size_t i = 0; i < n; i++)
+            {
+                if (std::abs(xs[i] - cx) <= win && std::abs(ys[i] - cy) <= win)
+                {
+                    clippedGlobal->insertPointFast(xs[i], ys[i], 0);
+                }
+            }
+        }
+        localObstaclesCache_.emplace(key, clippedGlobal);
     }
 
-    localObstaclesCache_.emplace(key, outObs);
-    return outObs;
+    // Per-call: rigid-transform the small clipped subset into the robot-local
+    // frame of `queryPose` (translation + rotation by heading).
+    auto         local = mrpt::maps::CSimplePointsMap::Create();
+    const auto   inv   = -mrpt::poses::CPose2D(queryPose);
+    const auto&  xs    = clippedGlobal->getPointsBufferRef_x();
+    const auto&  ys    = clippedGlobal->getPointsBufferRef_y();
+    const size_t n     = clippedGlobal->size();
+    local->reserve(n);
+    for (size_t i = 0; i < n; i++)
+    {
+        double ox = 0, oy = 0;
+        inv.composePoint(xs[i], ys[i], ox, oy);
+        local->insertPointFast(ox, oy, 0);
+    }
+    return local;
 }

--- a/tests/test_astar_diffdrive.cpp
+++ b/tests/test_astar_diffdrive.cpp
@@ -136,6 +136,29 @@ static mrpt::maps::CSimplePointsMap::Ptr buildCorridorWalls(
     return pts;
 }
 
+// A sealed rectangular box [x0,x1] x [y0,y1] (dense border points) with a solid
+// vertical divider at x=xdiv spanning the full height. The box prevents the
+// swept arcs from bulging "around" the obstacles, so a goal on the far side of
+// the divider is genuinely unreachable. Regression guard for the obstacle-cache
+// collision-soundness bug (the planner used to tunnel straight through).
+static mrpt::maps::CSimplePointsMap::Ptr buildSealedBoxWithDivider(
+    double x0, double x1, double y0, double y1, double xdiv)
+{
+    auto pts = mrpt::maps::CSimplePointsMap::Create();
+    for (double x = x0; x <= x1; x += 0.05)
+    {
+        pts->insertPoint(static_cast<float>(x), static_cast<float>(y0), 0.0f);
+        pts->insertPoint(static_cast<float>(x), static_cast<float>(y1), 0.0f);
+    }
+    for (double y = y0; y <= y1; y += 0.05)
+    {
+        pts->insertPoint(static_cast<float>(x0), static_cast<float>(y), 0.0f);
+        pts->insertPoint(static_cast<float>(x1), static_cast<float>(y), 0.0f);
+        pts->insertPoint(static_cast<float>(xdiv), static_cast<float>(y), 0.0f);
+    }
+    return pts;
+}
+
 static mpp::TPS_Astar buildPlanner()
 {
     mpp::TPS_Astar planner;
@@ -224,6 +247,30 @@ TEST(AstarDiffDrive, ForwardOnlyCannotReachBehindInCorridor)
     EXPECT_FALSE(out.success)
         << "Forward-only C-PTG must fail to reach a goal behind the robot in a "
            "corridor too narrow to turn around";
+}
+
+TEST(AstarDiffDrive, SolidWallBlocksGoal)
+{
+    // A sealed box split by a solid divider at x=1.0; start on the left, goal
+    // on the right. The goal is genuinely unreachable, so the planner MUST
+    // fail. Guards against the obstacle-cache bug where nodes sharing an
+    // xy-cell but with different headings reused mis-rotated obstacles, letting
+    // the planner tunnel straight through solid walls.
+    auto box = buildSealedBoxWithDivider(
+        /*x0=*/0.0, /*x1=*/2.0, /*y0=*/-1.0, /*y1=*/1.0, /*xdiv=*/1.0);
+
+    auto planner                           = buildPlanner();
+    planner.params_.maximumComputationTime = 10.0;
+
+    auto in = buildInput(
+        /*gx=*/1.5, /*gy=*/0.0, kCPtgForward,
+        /*bboxMin=*/{0.0, -1.0, -M_PI}, /*bboxMax=*/{2.0, 1.0, M_PI}, box);
+    in.stateStart.pose = {0.5, 0.0, 0.0};
+
+    const auto out = planner.plan(in);
+    EXPECT_FALSE(out.success)
+        << "Planner must NOT find a path through a solid wall (collision "
+           "soundness)";
 }
 
 TEST(AstarDiffDrive, ReverseReachesGoalBehind)

--- a/tests/test_obstacle_cache.cpp
+++ b/tests/test_obstacle_cache.cpp
@@ -230,12 +230,17 @@ TEST(ObstacleCache, WallClockSpeedup)
     rawTimer.getStats(rawStats);
     const double rawTotalTime = rawStats.at("raw").total_t;
 
-    // The total time spent inside cached_local_obstacles during the plan
-    // should be much less than the cost of doing all transforms from scratch.
-    EXPECT_LT(cachedTotalTime, rawTotalTime)
-        << "Total cached_local_obstacles time (" << cachedTotalTime * 1e3
-        << " ms) should be less than " << nCacheCalls
-        << " uncached transforms (" << rawTotalTime * 1e3 << " ms)";
+    // The cache stores the (heading-independent) CLIPPED GLOBAL subset; the
+    // heading-dependent rigid transform is correctly done per call (caching it
+    // across headings was a collision-soundness bug, see
+    // cached_local_obstacles). So the cache no longer eliminates the transform
+    // cost; it only avoids re-scanning the full global cloud per call. Assert
+    // it is not pathologically slower than recomputing from scratch (a generous
+    // bound, since this is a noise-prone micro-measurement).
+    EXPECT_LT(cachedTotalTime, rawTotalTime * 2.0)
+        << "cached_local_obstacles total (" << cachedTotalTime * 1e3
+        << " ms) vs " << nCacheCalls << " full transforms ("
+        << rawTotalTime * 1e3 << " ms)";
 
     std::cout << "[ObstacleCache] cached_total=" << cachedTotalTime * 1e3
               << " ms  " << nCacheCalls << " uncached transforms would cost "


### PR DESCRIPTION
## Critical correctness bug
`cached_local_obstacles` cached the local obstacle cloud keyed by the **xy grid cell only**, but `transform_pc_square_clipping` **rotates** obstacles into the node's heading frame. Nodes sharing an xy-cell with different headings reused obstacles rotated for the **wrong heading** → **collision false negatives**: the planner returned paths driving straight through solid walls.

**Repro:** sealed box with a solid divider, goal on the far side → planner returned success (a forward straight edge crossed a 0.6 m solid wall with no collision flagged). Confirmed by bypassing the cache (then correctly fails) and by tracing arc-to-obstacle distances (0.009 m, well inside the footprint). Pre-dates PRs #23-27.

## Fix
Cache only the heading-**independent** clipped GLOBAL obstacle subset (per xy-cell); do the heading-dependent rigid transform into the robot frame **per call**. Correctness restored; the cache still avoids re-scanning the full global cloud per call.

## Tests
- New `AstarDiffDrive.SolidWallBlocksGoal`: planner MUST fail to path through a solid wall in a sealed box.
- Relaxed `ObstacleCache.WallClockSpeedup` (it implicitly asserted the buggy transform-caching).
- 22/22 ctest pass.

## Impact
BARN 300-world success **300 → 292 (97.3%)** with correct collision — the prior 100% was partly tunneling through obstacles. This corrects the paper's headline comparison (DESIGN.md 12.5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a collision detection issue that could allow navigation paths to incorrectly pass through obstacles when robot orientation changed between planning iterations, improving path safety and accuracy.

* **Tests**
  * Added regression tests to verify that path planning correctly rejects any routes attempting to traverse through solid obstacles regardless of robot heading or orientation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->