### PR TITLE
feat(viz): SVG exporter for plans (debugging / paper figures)

### DIFF
--- a/apps/path-planner-cli/path-planner-cli.cpp
+++ b/apps/path-planner-cli/path-planner-cli.cpp
@@ -10,6 +10,7 @@
 #include <mpp/algos/refine_trajectory.h>
 #include <mpp/algos/trajectories.h>
 #include <mpp/algos/viz.h>
+#include <mpp/algos/viz_svg.h>
 #include <mpp/data/Waypoints.h>
 #include <mrpt/3rdparty/tclap/CmdLine.h>
 #include <mrpt/config/CConfigFile.h>
@@ -141,6 +142,12 @@ TCLAP::ValueArg<std::string> arg_InterpolatePath(
     "", "save-interpolated-path",
     "Interpolates the path and saves it into a .csv file", false, "path.csv",
     "path.csv", cmd);
+
+TCLAP::ValueArg<std::string> arg_save_svg(
+    "", "save-svg",
+    "Saves a 2D SVG plot of the plan (obstacles, tree, path, robot shapes) for "
+    "debugging / paper figures",
+    false, "", "plan.svg", cmd);
 
 TCLAP::SwitchArg arg_playAnimation(
     "", "play-animation",
@@ -345,6 +352,15 @@ static void do_plan_path()
     std::cout << "Plan has " << plan.motionTree.edges_to_children.size()
               << " overall edges, " << plan.motionTree.nodes().size()
               << " nodes\n";
+
+    if (arg_save_svg.isSet())
+    {
+        if (mpp::save_plan_to_svg(plan, arg_save_svg.getValue()))
+            std::cout << "Saved SVG plot: " << arg_save_svg.getValue() << "\n";
+        else
+            std::cerr << "Could not write SVG: " << arg_save_svg.getValue()
+                      << "\n";
+    }
 
     if (!plan.bestNodeId.has_value())
     {

--- a/mrpt_path_planning/include/mpp/algos/viz_svg.h
+++ b/mrpt_path_planning/include/mpp/algos/viz_svg.h
@@ -1,0 +1,66 @@
+/* -------------------------------------------------------------------------
+ *   SelfDriving C++ library based on PTGs and mrpt-nav
+ * Copyright (C) 2019-2026 Jose Luis Blanco, University of Almeria
+ * See LICENSE for license information.
+ * ------------------------------------------------------------------------- */
+
+#pragma once
+
+#include <mpp/data/PlannerOutput.h>
+
+#include <string>
+
+namespace mpp
+{
+/** Options for the 2D SVG plan exporter (save_plan_to_svg / plan_to_svg).
+ *  Colors are SVG color strings (e.g. "#cc0000" or "none"). */
+struct SvgExportOptions
+{
+    double image_width_px =
+        900;  //!< target image width; height auto from aspect
+    double margin_px = 25;
+
+    bool draw_obstacles    = true;
+    bool draw_tree         = true;  //!< full motion tree (faint)
+    bool draw_path         = true;  //!< solution / best path (bold)
+    bool draw_robot_shapes = true;  //!< footprint along the path
+    bool draw_start_goal   = true;
+    bool draw_bbox         = true;
+    bool draw_scalebar     = true;
+
+    /** Draw one robot footprint out of every N interpolated path poses
+     *  (plus always at start and goal). 0 => only at start and goal. */
+    size_t robot_shape_decimation = 8;
+
+    /** Plot one obstacle point out of every N (1 = all). */
+    size_t obstacle_decimation = 1;
+
+    std::string color_background = "#ffffff";
+    std::string color_obstacles  = "#2255cc";
+    std::string color_tree       = "#bdbdbd";
+    std::string color_path       = "#cc0000";
+    std::string color_robot      = "#cc0000";
+    std::string color_robot_fill = "none";
+    std::string color_start      = "#118811";
+    std::string color_goal       = "#cc0000";
+    std::string color_bbox       = "#888888";
+
+    double stroke_path_px     = 2.5;
+    double stroke_tree_px     = 0.6;
+    double stroke_robot_px    = 1.0;
+    double obstacle_radius_px = 1.4;
+};
+
+/** Returns an SVG document (as a string) with a top-down 2D plot of a planner
+ *  result: world bounding box, obstacles, the motion tree, the solution (or
+ *  best) path, the robot footprint along it, and start/goal markers. Intended
+ *  for debugging and for vector figures in papers (no OpenGL/GUI needed). */
+std::string plan_to_svg(
+    const PlannerOutput& plan, const SvgExportOptions& opts = {});
+
+/** Writes plan_to_svg() to `filename`. Returns false on I/O error. */
+bool save_plan_to_svg(
+    const PlannerOutput& plan, const std::string& filename,
+    const SvgExportOptions& opts = {});
+
+}  // namespace mpp

--- a/mrpt_path_planning/src/algos/viz_svg.cpp
+++ b/mrpt_path_planning/src/algos/viz_svg.cpp
@@ -1,0 +1,288 @@
+/* -------------------------------------------------------------------------
+ *   SelfDriving C++ library based on PTGs and mrpt-nav
+ * Copyright (C) 2019-2026 Jose Luis Blanco, University of Almeria
+ * See LICENSE for license information.
+ * ------------------------------------------------------------------------- */
+
+#include <mpp/algos/viz_svg.h>
+#include <mrpt/poses/CPose2D.h>
+
+#include <cmath>
+#include <fstream>
+#include <sstream>
+#include <variant>
+#include <vector>
+
+using namespace mpp;
+
+namespace
+{
+// World->image transform (SVG y points down, so the world y axis is flipped).
+struct Frame
+{
+    double xmin, ymin, ymax, scale, margin;
+    double tx(double x) const { return margin + (x - xmin) * scale; }
+    double ty(double y) const { return margin + (ymax - y) * scale; }
+};
+
+std::string fmt(double v)
+{
+    std::ostringstream s;
+    s << std::fixed;
+    s.precision(2);
+    s << v;
+    return s.str();
+}
+
+// Append the robot footprint (polygon or circle) at a global pose.
+void appendRobotShape(
+    std::ostream& os, const RobotShape& shape, const mrpt::math::TPose2D& pose,
+    const Frame& fr, const SvgExportOptions& o)
+{
+    if (std::holds_alternative<mrpt::math::TPolygon2D>(shape))
+    {
+        const auto& poly = std::get<mrpt::math::TPolygon2D>(shape);
+        const mrpt::poses::CPose2D p(pose);
+        os << "<polygon points=\"";
+        for (const auto& v : poly)
+        {
+            double gx = 0, gy = 0;
+            p.composePoint(v.x, v.y, gx, gy);
+            os << fmt(fr.tx(gx)) << "," << fmt(fr.ty(gy)) << " ";
+        }
+        os << "\" fill=\"" << o.color_robot_fill << "\" stroke=\""
+           << o.color_robot << "\" stroke-width=\"" << o.stroke_robot_px
+           << "\"/>\n";
+    }
+    else if (std::holds_alternative<robot_radius_t>(shape))
+    {
+        const double r = std::get<robot_radius_t>(shape);
+        os << "<circle cx=\"" << fmt(fr.tx(pose.x)) << "\" cy=\""
+           << fmt(fr.ty(pose.y)) << "\" r=\"" << fmt(r * fr.scale)
+           << "\" fill=\"" << o.color_robot_fill << "\" stroke=\""
+           << o.color_robot << "\" stroke-width=\"" << o.stroke_robot_px
+           << "\"/>\n";
+    }
+}
+
+// Global poses sampled along an edge (interpolatedPath if present, else the
+// straight from->to segment as a fallback, e.g. for deferred-interpolation
+// tree edges).
+std::vector<mrpt::math::TPose2D> edgePoses(const MoveEdgeSE2_TPS& e)
+{
+    std::vector<mrpt::math::TPose2D> out;
+    if (e.interpolatedPath.size() >= 2)
+    {
+        for (const auto& [t, relPose] : e.interpolatedPath)
+        {
+            (void)t;
+            out.push_back(e.stateFrom.pose + relPose);
+        }
+    }
+    else
+    {
+        out.push_back(e.stateFrom.pose);
+        out.push_back(e.stateTo.pose);
+    }
+    return out;
+}
+
+void polyline(
+    std::ostream& os, const std::vector<mrpt::math::TPose2D>& pts,
+    const Frame& fr, const std::string& color, double width)
+{
+    if (pts.size() < 2) return;
+    os << "<polyline fill=\"none\" stroke=\"" << color << "\" stroke-width=\""
+       << width << "\" points=\"";
+    for (const auto& p : pts)
+        os << fmt(fr.tx(p.x)) << "," << fmt(fr.ty(p.y)) << " ";
+    os << "\"/>\n";
+}
+
+void marker(
+    std::ostream& os, const mrpt::math::TPose2D& p, const Frame& fr,
+    const std::string& color)
+{
+    const double cx = fr.tx(p.x);
+    const double cy = fr.ty(p.y);
+    os << "<circle cx=\"" << fmt(cx) << "\" cy=\"" << fmt(cy)
+       << "\" r=\"5\" fill=\"" << color << "\"/>\n";
+    // heading tick (note: image y is flipped, so use -sin for screen):
+    const double hx = cx + 12.0 * std::cos(p.phi);
+    const double hy = cy - 12.0 * std::sin(p.phi);
+    os << "<line x1=\"" << fmt(cx) << "\" y1=\"" << fmt(cy) << "\" x2=\""
+       << fmt(hx) << "\" y2=\"" << fmt(hy) << "\" stroke=\"" << color
+       << "\" stroke-width=\"2\"/>\n";
+}
+}  // namespace
+
+std::string mpp::plan_to_svg(
+    const PlannerOutput& plan, const SvgExportOptions& o)
+{
+    const auto& pi = plan.originalInput;
+
+    // Drawing extent: union of the world bbox, obstacles, and all tree node
+    // poses, so that legitimate path "bulges" outside the planning bbox (e.g.
+    // an arc routing around a finite wall through free space) are NOT clipped
+    // off-canvas. This makes such behavior visible for debugging.
+    double     xmin = pi.worldBboxMin.x, xmax = pi.worldBboxMax.x;
+    double     ymin = pi.worldBboxMin.y, ymax = pi.worldBboxMax.y;
+    const auto grow = [&](double x, double y)
+    {
+        xmin = std::min(xmin, x);
+        xmax = std::max(xmax, x);
+        ymin = std::min(ymin, y);
+        ymax = std::max(ymax, y);
+    };
+    for (const auto& kv : plan.motionTree.nodes())
+        grow(kv.second.pose.x, kv.second.pose.y);
+    for (const auto& os_src : pi.obstacles)
+    {
+        if (!os_src || !os_src->obstacles()) continue;
+        const auto& xs = os_src->obstacles()->getPointsBufferRef_x();
+        const auto& ys = os_src->obstacles()->getPointsBufferRef_y();
+        for (size_t i = 0; i < os_src->obstacles()->size(); i++)
+            grow(xs[i], ys[i]);
+    }
+    // a little world-space padding so footprints near the edge are not cut:
+    const double pad = 0.5;
+    xmin -= pad;
+    xmax += pad;
+    ymin -= pad;
+    ymax += pad;
+
+    Frame fr;
+    fr.xmin             = xmin;
+    fr.ymin             = ymin;
+    fr.ymax             = ymax;
+    fr.margin           = o.margin_px;
+    const double worldW = xmax - xmin;
+    const double worldH = ymax - ymin;
+    fr.scale =
+        (worldW > 0) ? (o.image_width_px - 2 * o.margin_px) / worldW : 1.0;
+    const double imgW = o.image_width_px;
+    const double imgH = worldH * fr.scale + 2 * o.margin_px;
+
+    std::ostringstream os;
+    os << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
+    os << "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"" << fmt(imgW)
+       << "\" height=\"" << fmt(imgH) << "\" viewBox=\"0 0 " << fmt(imgW) << " "
+       << fmt(imgH) << "\">\n";
+    os << "<rect width=\"100%\" height=\"100%\" fill=\"" << o.color_background
+       << "\"/>\n";
+
+    // World bounding box:
+    if (o.draw_bbox)
+    {
+        os << "<rect x=\"" << fmt(fr.tx(pi.worldBboxMin.x)) << "\" y=\""
+           << fmt(fr.ty(pi.worldBboxMax.y)) << "\" width=\""
+           << fmt(worldW * fr.scale) << "\" height=\"" << fmt(worldH * fr.scale)
+           << "\" fill=\"none\" stroke=\"" << o.color_bbox
+           << "\" stroke-width=\"1\"/>\n";
+    }
+
+    // Obstacles:
+    if (o.draw_obstacles)
+    {
+        os << "<g fill=\"" << o.color_obstacles << "\">\n";
+        const size_t dec = std::max<size_t>(1, o.obstacle_decimation);
+        for (const auto& os_src : pi.obstacles)
+        {
+            if (!os_src) continue;
+            const auto obs = os_src->obstacles();
+            if (!obs) continue;
+            const auto& xs = obs->getPointsBufferRef_x();
+            const auto& ys = obs->getPointsBufferRef_y();
+            for (size_t i = 0; i < obs->size(); i += dec)
+            {
+                os << "<circle cx=\"" << fmt(fr.tx(xs[i])) << "\" cy=\""
+                   << fmt(fr.ty(ys[i])) << "\" r=\"" << o.obstacle_radius_px
+                   << "\"/>\n";
+            }
+        }
+        os << "</g>\n";
+    }
+
+    // Full motion tree (faint):
+    if (o.draw_tree)
+    {
+        os << "<g>\n";
+        for (const auto& kv : plan.motionTree.edges_to_children)
+        {
+            for (const auto& entry : kv.second)
+            {
+                polyline(
+                    os, edgePoses(entry.data), fr, o.color_tree,
+                    o.stroke_tree_px);
+            }
+        }
+        os << "</g>\n";
+    }
+
+    // Solution / best path (bold) + robot shapes along it:
+    const auto bestId = plan.bestNodeId ? plan.bestNodeId : plan.goalNodeId;
+    if (o.draw_path && bestId.has_value() &&
+        plan.motionTree.nodes().count(bestId.value()))
+    {
+        const auto [nodes, edges] =
+            plan.motionTree.backtrack_path(bestId.value());
+        (void)nodes;
+
+        std::vector<mrpt::math::TPose2D> full;
+        for (const auto* e : edges)
+        {
+            if (!e) continue;
+            const auto ps = edgePoses(*e);
+            full.insert(full.end(), ps.begin(), ps.end());
+        }
+        polyline(os, full, fr, o.color_path, o.stroke_path_px);
+
+        if (o.draw_robot_shapes && !full.empty())
+        {
+            os << "<g>\n";
+            if (o.robot_shape_decimation > 0)
+            {
+                for (size_t i = 0; i < full.size();
+                     i += o.robot_shape_decimation)
+                    appendRobotShape(os, pi.ptgs.robotShape, full[i], fr, o);
+            }
+            appendRobotShape(os, pi.ptgs.robotShape, full.front(), fr, o);
+            appendRobotShape(os, pi.ptgs.robotShape, full.back(), fr, o);
+            os << "</g>\n";
+        }
+    }
+
+    // Start & goal markers:
+    if (o.draw_start_goal)
+    {
+        marker(os, pi.stateStart.pose, fr, o.color_start);
+        marker(os, pi.stateGoal.asSE2KinState().pose, fr, o.color_goal);
+    }
+
+    // Scale bar (1 m) + status text:
+    if (o.draw_scalebar)
+    {
+        const double y = imgH - 8;
+        os << "<line x1=\"" << fmt(o.margin_px) << "\" y1=\"" << fmt(y)
+           << "\" x2=\"" << fmt(o.margin_px + fr.scale) << "\" y2=\"" << fmt(y)
+           << "\" stroke=\"#000000\" stroke-width=\"2\"/>\n";
+        os << "<text x=\"" << fmt(o.margin_px) << "\" y=\"" << fmt(y - 4)
+           << "\" font-size=\"11\" font-family=\"sans-serif\">1 m</text>\n";
+    }
+    os << "<text x=\"" << fmt(o.margin_px) << "\" y=\"16\" font-size=\"12\" "
+       << "font-family=\"sans-serif\">" << (plan.success ? "success" : "FAILED")
+       << "</text>\n";
+
+    os << "</svg>\n";
+    return os.str();
+}
+
+bool mpp::save_plan_to_svg(
+    const PlannerOutput& plan, const std::string& filename,
+    const SvgExportOptions& o)
+{
+    std::ofstream f(filename);
+    if (!f.is_open()) return false;
+    f << plan_to_svg(plan, o);
+    return f.good();
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,6 +33,12 @@ selfdriving_add_test(
 )
 
 selfdriving_add_test(
+    TARGET  test_viz_svg
+    SOURCES test_viz_svg.cpp
+    LINK_LIBRARIES mrpt_path_planning GTest::GTest GTest::Main
+)
+
+selfdriving_add_test(
     TARGET  test_edge_interpolation
     SOURCES test_edge_interpolation.cpp
     LINK_LIBRARIES mrpt_path_planning GTest::GTest GTest::Main

--- a/tests/test_viz_svg.cpp
+++ b/tests/test_viz_svg.cpp
@@ -1,0 +1,95 @@
+/* -------------------------------------------------------------------------
+ *   SelfDriving C++ library based on PTGs and mrpt-nav
+ * Copyright (C) 2019-2026 Jose Luis Blanco, University of Almeria
+ * See LICENSE for license information.
+ * ------------------------------------------------------------------------- */
+
+/** Unit tests for the SVG plan exporter (plan_to_svg / save_plan_to_svg). */
+
+#include <gtest/gtest.h>
+#include <mpp/algos/TPS_Astar.h>
+#include <mpp/algos/viz_svg.h>
+#include <mpp/data/PlannerInput.h>
+#include <mrpt/config/CConfigFileMemory.h>
+
+#include <cstdio>
+#include <fstream>
+
+static const char* kCfg = R"cfg(
+[SelfDriving]
+min_obstacles_height = 0.0
+max_obstacles_height = 2.0
+PTG_COUNT = 1
+PTG0_Type        = mpp::ptg::HolonomicBlend
+PTG0_refDistance = 5.0
+PTG0_num_paths   = 31
+PTG0_T_ramp_max  = 1.0
+PTG0_v_max_mps   = 1.0
+PTG0_w_max_dps   = 60.0
+PTG0_expr_V      = V_MAX * trimmable_speed
+PTG0_expr_W      = W_MAX * trimmable_speed
+PTG0_expr_T_ramp = T_ramp_max
+RobotModel_circular_shape_radius = 0.20
+)cfg";
+
+static mpp::PlannerOutput planSimple()
+{
+    mrpt::config::CConfigFileMemory cfg(kCfg);
+    mpp::PlannerInput               in;
+    in.ptgs.initFromConfigFile(cfg, "SelfDriving");
+    in.stateStart.pose = {0, 0, 0};
+    in.stateGoal.state = mrpt::math::TPoint2D{3.0, 1.0};
+    in.worldBboxMin    = {-2, -2, -M_PI};
+    in.worldBboxMax    = {5, 4, M_PI};
+
+    mpp::TPS_Astar planner;
+    planner.setMinLoggingLevel(mrpt::system::LVL_ERROR);
+    planner.params_.maximumComputationTime = 20.0;
+    return planner.plan(in);
+}
+
+TEST(VizSvg, ProducesWellFormedSvg)
+{
+    const auto out = planSimple();
+    ASSERT_TRUE(out.success);
+
+    const std::string svg = mpp::plan_to_svg(out);
+
+    EXPECT_NE(svg.find("<?xml"), std::string::npos);
+    EXPECT_NE(svg.find("<svg"), std::string::npos);
+    EXPECT_NE(svg.find("</svg>"), std::string::npos);
+    // a bold solution path polyline must be present:
+    EXPECT_NE(svg.find("polyline"), std::string::npos);
+    // start/goal markers (circles) present:
+    EXPECT_NE(svg.find("<circle"), std::string::npos);
+}
+
+TEST(VizSvg, SaveToFile)
+{
+    const auto        out = planSimple();
+    const std::string fn  = "test_viz_svg_output.svg";
+    ASSERT_TRUE(mpp::save_plan_to_svg(out, fn));
+
+    std::ifstream f(fn);
+    ASSERT_TRUE(f.is_open());
+    std::string first;
+    std::getline(f, first);
+    EXPECT_NE(first.find("<?xml"), std::string::npos);
+    f.close();
+    std::remove(fn.c_str());
+}
+
+TEST(VizSvg, OptionsTogglesReduceOutput)
+{
+    const auto out = planSimple();
+
+    mpp::SvgExportOptions full;  // everything on
+    mpp::SvgExportOptions minimal;
+    minimal.draw_obstacles    = false;
+    minimal.draw_tree         = false;
+    minimal.draw_robot_shapes = false;
+
+    EXPECT_GT(
+        mpp::plan_to_svg(out, full).size(),
+        mpp::plan_to_svg(out, minimal).size());
+}


### PR DESCRIPTION
## What
A dependency-free, GUI-less 2D **SVG** exporter for planner results, alongside the existing OpenGL viz: `mpp::plan_to_svg()` / `mpp::save_plan_to_svg()` (`mpp/algos/viz_svg.h`).

Draws: world bbox, obstacles, the full motion tree (faint), the solution/best path (bold), the robot **footprint** (polygon or circular) along the path, and start/goal markers with heading. Configurable via `SvgExportOptions` (colors, decimation, which layers).

The canvas **auto-fits to content** (world bbox ∪ obstacles ∪ tree), so legitimate path *bulges* outside the planning bbox (e.g. an arc routing around a finite wall through free space) are visible instead of clipped — handy for debugging collision/footprint behavior and for vector figures in papers.

## CLI
`path-planner-cli --save-svg plan.svg`

## Tests
`test_viz_svg`: well-formed SVG, save-to-file, option toggles. 24/24 ctest pass.

## Why SVG
Vector (scales cleanly in LaTeX), text/diff-able, no OpenGL/GUI/X needed (works headless/CI), trivially convertible to PDF/PNG.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Motion planning outputs can now be saved as SVG files using the new `--save-svg` CLI argument
  * SVG visualizations include planned trajectory, obstacles, motion tree, robot footprint overlay, start/goal markers, and reference scale bar
  * Customizable export options to toggle visualization elements and adjust image dimensions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->