### PR TITLE
feat(cli): add --no-gui and SVG motion-tree decimation

### DIFF
--- a/apps/path-planner-cli/path-planner-cli.cpp
+++ b/apps/path-planner-cli/path-planner-cli.cpp
@@ -154,6 +154,22 @@ TCLAP::SwitchArg arg_playAnimation(
     "Shows the GUI with an animation of the vehicle moving along the path",
     cmd);
 
+TCLAP::SwitchArg arg_noGui(
+    "", "no-gui",
+    "Do not open any GUI window (for headless/batch use, e.g. mass figure "
+    "export). The process exits without waiting for a window to be closed.",
+    cmd);
+
+TCLAP::ValueArg<size_t> arg_svg_tree_decimation(
+    "", "svg-tree-decimation",
+    "When exporting SVG, draw only one motion-tree edge out of every N. Use a "
+    "larger value to thin out very dense (e.g. failed-query) trees.",
+    false, 1, "1", cmd);
+
+TCLAP::SwitchArg arg_svg_no_tree(
+    "", "svg-no-tree", "When exporting SVG, omit the motion tree entirely.",
+    cmd);
+
 static mrpt::maps::CPointsMap::Ptr load_obstacles()
 {
     auto obsPts = mrpt::maps::CSimplePointsMap::Create();
@@ -355,7 +371,10 @@ static void do_plan_path()
 
     if (arg_save_svg.isSet())
     {
-        if (mpp::save_plan_to_svg(plan, arg_save_svg.getValue()))
+        mpp::SvgExportOptions svgOpts;
+        svgOpts.draw_tree      = !arg_svg_no_tree.isSet();
+        svgOpts.tree_decimation = arg_svg_tree_decimation.getValue();
+        if (mpp::save_plan_to_svg(plan, arg_save_svg.getValue(), svgOpts))
             std::cout << "Saved SVG plot: " << arg_save_svg.getValue() << "\n";
         else
             std::cerr << "Could not write SVG: " << arg_save_svg.getValue()
@@ -431,7 +450,8 @@ static void do_plan_path()
         }
     }
 
-    // GUI:
+    // GUI (skipped entirely in headless/batch mode):
+    if (arg_noGui.isSet()) return;
     if (!arg_playAnimation.isSet() || !traj.has_value())
     {
         // regular UI:

--- a/mrpt_path_planning/include/mpp/algos/viz_svg.h
+++ b/mrpt_path_planning/include/mpp/algos/viz_svg.h
@@ -35,6 +35,11 @@ struct SvgExportOptions
     /** Plot one obstacle point out of every N (1 = all). */
     size_t obstacle_decimation = 1;
 
+    /** Draw one motion-tree edge out of every N (1 = all). Use a larger value
+     *  to thin out a very dense exhaustive-search tree (e.g. failed queries)
+     *  into a visually usable figure instead of tens of thousands of edges. */
+    size_t tree_decimation = 1;
+
     std::string color_background = "#ffffff";
     std::string color_obstacles  = "#2255cc";
     std::string color_tree       = "#bdbdbd";

--- a/mrpt_path_planning/src/algos/viz_svg.cpp
+++ b/mrpt_path_planning/src/algos/viz_svg.cpp
@@ -218,10 +218,13 @@ std::string mpp::plan_to_svg(
     if (o.draw_tree)
     {
         os << "<g>\n";
+        const size_t treeDec = o.tree_decimation > 0 ? o.tree_decimation : 1;
+        size_t       edgeIdx = 0;
         for (const auto& kv : plan.motionTree.edges_to_children)
         {
             for (const auto& entry : kv.second)
             {
+                if ((edgeIdx++ % treeDec) != 0) continue;
                 polyline(
                     os, edgePoses(entry.data), fr, o.color_tree,
                     o.stroke_tree_px);


### PR DESCRIPTION
## Why

Two pain points hit while mass-exporting plan figures for the TPS-A* paper:

1. **`path-planner-cli` always opened a blocking GUI window** (`viz_nav_plan`)
   on completion, even with `--save-svg`. In headless/batch loops this silently
   hangs waiting for an offscreen window to be closed (looks like a ~2 min
   timeout but is really a stuck window).
2. **Failed (exhausted) queries produce a huge motion tree** (tens of thousands
   of edges → 10+ MB SVGs), unusable as figures.

## What

- `path-planner-cli --no-gui`: skip all GUI, exit immediately (headless/batch).
- `SvgExportOptions::tree_decimation` (draw 1 tree edge in N).
- `path-planner-cli --svg-tree-decimation N` and `--svg-no-tree`.

Effect on a dense failed BARN world: 10.9 MB / 63k edges → 0.5 MB / 3.2k edges
at N=20, still clearly showing the searched region + footprints.

## Test

`test_viz_svg` passes (incl. existing `OptionsTogglesReduceOutput`). Manually
verified `--no-gui` exits without a window and decimation thins the SVG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--no-gui` CLI option to skip the graphical interface after planning.
  * Added `--svg-tree-decimation` and `--svg-no-tree` CLI options to customize motion-tree rendering in SVG exports, including edge decimation for thinning dense trees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->