### PR TITLE
feat(costmap): footprint-aware CostEvaluatorCostMap

### DIFF
--- a/apps/path-planner-cli/path-planner-cli.cpp
+++ b/apps/path-planner-cli/path-planner-cli.cpp
@@ -290,6 +290,15 @@ static void do_plan_path()
     // Enable time profiler:
     planner->profiler_().enable(true);
 
+    // PTGs config file (loaded before the costmap so the robot shape is
+    // available to make the costmap footprint-aware):
+    std::cout << "[PTGs] Initializing PTGs..." << std::endl;
+
+    mrpt::config::CConfigFile cfg(arg_ptgs_file.getValue());
+    pi.ptgs.initFromConfigFile(cfg, arg_config_file_section.getValue());
+
+    std::cout << "[PTGs] Done." << std::endl;
+
     if (arg_costMap.isSet())
     {
         // cost map:
@@ -298,7 +307,7 @@ static void do_plan_path()
                 mrpt::containers::yaml::FromFile(arg_costMap.getValue()));
 
         auto costmap = mpp::CostEvaluatorCostMap::FromStaticPointObstacles(
-            *obsPts, costMapParams, pi.stateStart.pose);
+            *obsPts, costMapParams, pi.stateStart.pose, pi.ptgs.robotShape);
 
         planner->costEvaluators_.push_back(costmap);
     }
@@ -349,14 +358,6 @@ static void do_plan_path()
                   << " bestCostToGoal: " << pcd.bestCostToGoal
                   << " bestPathLength: " << pcd.bestPath.size() << std::endl;
     };
-
-    // PTGs config file:
-    std::cout << "[PTGs] Initializing PTGs..." << std::endl;
-
-    mrpt::config::CConfigFile cfg(arg_ptgs_file.getValue());
-    pi.ptgs.initFromConfigFile(cfg, arg_config_file_section.getValue());
-
-    std::cout << "[PTGs] Done." << std::endl;
 
     // ==================================================
     // ACTUAL PATH PLANNING

--- a/apps/selfdriving-simulator-gui/selfdriving-simulator-gui.cpp
+++ b/apps/selfdriving-simulator-gui/selfdriving-simulator-gui.cpp
@@ -1001,7 +1001,8 @@ void on_do_single_path_planning(
     {
         auto staticCostmap =
             mpp::CostEvaluatorCostMap::FromStaticPointObstacles(
-                *obsPts, cmP, pi.stateStart.pose);
+                *obsPts, cmP, pi.stateStart.pose,
+                sd->navigator.config_.ptgs.robotShape);
 
         planner.costEvaluators_.push_back(staticCostmap);
     }
@@ -1015,7 +1016,8 @@ void on_do_single_path_planning(
         {
             auto lidarCostmap =
                 mpp::CostEvaluatorCostMap::FromStaticPointObstacles(
-                    *obs, cmP, pi.stateStart.pose);
+                    *obs, cmP, pi.stateStart.pose,
+                    sd->navigator.config_.ptgs.robotShape);
 
             planner.costEvaluators_.push_back(lidarCostmap);
         }

--- a/mrpt_path_planning/include/mpp/algos/CostEvaluatorCostMap.h
+++ b/mrpt_path_planning/include/mpp/algos/CostEvaluatorCostMap.h
@@ -7,8 +7,12 @@
 #pragma once
 
 #include <mpp/algos/CostEvaluator.h>
+#include <mpp/data/TrajectoriesAndRobotShape.h>  // RobotShape
 #include <mrpt/containers/CDynamicGrid.h>
 #include <mrpt/maps/CPointsMap.h>
+#include <mrpt/math/TPoint2D.h>
+
+#include <vector>
 
 namespace mpp
 {
@@ -50,10 +54,21 @@ class CostEvaluatorCostMap : public CostEvaluator
         void                   load_from_yaml(const mrpt::containers::yaml& c);
     };
 
+    /** Builds a costmap from static point obstacles.
+     *
+     * If `robotShape` is given (a polygon or a radius), the per-edge cost is
+     * the maximum costmap value sampled over the robot footprint transformed to
+     * each path pose, instead of a single sample at the trajectory reference
+     * point (base_link origin). This makes `preferredClearanceDistance`
+     * correspond to actual footprint clearance for non-point robots. A
+     * `std::monostate` shape (the default) keeps the legacy origin-only
+     * behavior.
+     */
     static CostEvaluatorCostMap::Ptr FromStaticPointObstacles(
         const mrpt::maps::CPointsMap&             obsPts,
         const Parameters&                         p            = Parameters(),
-        const std::optional<mrpt::math::TPose2D>& curRobotPose = std::nullopt);
+        const std::optional<mrpt::math::TPose2D>& curRobotPose = std::nullopt,
+        const RobotShape& robotShape = std::monostate{});
 
     /** Evaluate cost of move-tree edge */
     double operator()(const MoveEdgeSE2_TPS& edge) const override;
@@ -70,9 +85,25 @@ class CostEvaluatorCostMap : public CostEvaluator
 
     const Parameters& params() const { return params_; }
 
+    /** Sample points (robot frame) over which the footprint cost is evaluated;
+     * empty means legacy origin-only sampling. Exposed for
+     * testing/visualization.
+     */
+    const std::vector<mrpt::math::TPoint2D>& shape_samples() const
+    {
+        return shapeSamples_;
+    }
+
    private:
     cost_gridmap_t costmap_;
     Parameters     params_;
+
+    /** Precomputed footprint sample points in the robot frame. When non-empty,
+     * `eval_single_pose` returns the max cost over these points transformed to
+     * the query pose. Built once by `FromStaticPointObstacles` from
+     * `RobotShape`.
+     */
+    std::vector<mrpt::math::TPoint2D> shapeSamples_;
 
     double eval_single_pose(const mrpt::math::TPose2D& p) const;
 };

--- a/mrpt_path_planning/include/mpp/algos/CostEvaluatorCostMap.h
+++ b/mrpt_path_planning/include/mpp/algos/CostEvaluatorCostMap.h
@@ -14,6 +14,12 @@
 
 #include <vector>
 
+/** Feature-test macro: defined (=1) since `FromStaticPointObstacles()` gained
+ * the optional `RobotShape` argument (footprint-aware costmap). Downstream code
+ * can `#if defined(MPP_COSTEVALUATORCOSTMAP_HAS_ROBOT_SHAPE)` to stay
+ * source-compatible with older mpp releases that lack that overload. */
+#define MPP_COSTEVALUATORCOSTMAP_HAS_ROBOT_SHAPE 1
+
 namespace mpp
 {
 /** Defines higher costs to paths that pass closer to obstacles.

--- a/mrpt_path_planning/src/algos/CostEvaluatorCostMap.cpp
+++ b/mrpt_path_planning/src/algos/CostEvaluatorCostMap.cpp
@@ -63,17 +63,33 @@ namespace
 // maximum costmap value over these points (transformed to a path pose) then
 // reflects the true footprint clearance, not just the reference-point
 // clearance.
+//
+// This runs on the cost-evaluation hot path (per interpolated pose, per edge),
+// so the total sample count is capped: sampling finer than the costmap
+// resolution is wasted (adjacent samples fall in the same cell), and for very
+// large footprints the perimeter step is coarsened to keep the count bounded.
 std::vector<mrpt::math::TPoint2D> buildShapeSamples(
     const mpp::RobotShape& shape, double resolution)
 {
+    constexpr size_t MAX_SAMPLES = 128;
+
     std::vector<mrpt::math::TPoint2D> pts;
-    const double                      step = std::max(0.01, resolution);
+    const double                      res = std::max(0.01, resolution);
 
     if (const auto* poly = std::get_if<mrpt::math::TPolygon2D>(&shape))
     {
         const auto&  v = *poly;
         const size_t n = v.size();
         if (n < 2) return pts;
+
+        double perimeter = 0;
+        for (size_t i = 0; i < n; i++)
+            perimeter += (v[(i + 1) % n] - v[i]).norm();
+
+        // Step at the grid resolution, coarsened if needed to stay under the
+        // cap.
+        const double step = std::max(res, perimeter / MAX_SAMPLES);
+
         for (size_t i = 0; i < n; i++)
         {
             const auto&  a   = v[i];
@@ -93,7 +109,8 @@ std::vector<mrpt::math::TPoint2D> buildShapeSamples(
     {
         const double r = *radius;
         if (r <= 0) return pts;
-        const int nSeg =
+        const double step = std::max(res, 2 * M_PI * r / MAX_SAMPLES);
+        const int    nSeg =
             std::max(8, static_cast<int>(std::ceil(2 * M_PI * r / step)));
         for (int k = 0; k < nSeg; k++)
         {

--- a/mrpt_path_planning/src/algos/CostEvaluatorCostMap.cpp
+++ b/mrpt_path_planning/src/algos/CostEvaluatorCostMap.cpp
@@ -9,6 +9,9 @@
 #include <mrpt/maps/COccupancyGridMap2D.h>
 #include <mrpt/opengl/CTexturedPlane.h>
 
+#include <algorithm>
+#include <cmath>
+
 using namespace mpp;
 
 IMPLEMENTS_MRPT_OBJECT(CostEvaluatorCostMap, CostEvaluator, mpp)
@@ -51,13 +54,68 @@ void CostEvaluatorCostMap::Parameters::load_from_yaml(
 
 CostEvaluatorCostMap::~CostEvaluatorCostMap() = default;
 
+namespace
+{
+// Builds the set of robot-frame points at which the footprint cost is sampled.
+// For a polygon: its vertices plus points subdividing each edge finer than the
+// costmap resolution, so the max cost picks up the footprint side/corner
+// closest to an obstacle. For a radius: a ring of points at that radius. The
+// maximum costmap value over these points (transformed to a path pose) then
+// reflects the true footprint clearance, not just the reference-point
+// clearance.
+std::vector<mrpt::math::TPoint2D> buildShapeSamples(
+    const mpp::RobotShape& shape, double resolution)
+{
+    std::vector<mrpt::math::TPoint2D> pts;
+    const double                      step = std::max(0.01, resolution);
+
+    if (const auto* poly = std::get_if<mrpt::math::TPolygon2D>(&shape))
+    {
+        const auto&  v = *poly;
+        const size_t n = v.size();
+        if (n < 2) return pts;
+        for (size_t i = 0; i < n; i++)
+        {
+            const auto&  a   = v[i];
+            const auto&  b   = v[(i + 1) % n];
+            const double len = std::hypot(b.x - a.x, b.y - a.y);
+            const int    nSeg =
+                std::max(1, static_cast<int>(std::ceil(len / step)));
+            for (int k = 0; k < nSeg;
+                 k++)  // include a, exclude b (next edge's a)
+            {
+                const double t = static_cast<double>(k) / nSeg;
+                pts.emplace_back(a.x + t * (b.x - a.x), a.y + t * (b.y - a.y));
+            }
+        }
+    }
+    else if (const auto* radius = std::get_if<mpp::robot_radius_t>(&shape))
+    {
+        const double r = *radius;
+        if (r <= 0) return pts;
+        const int nSeg =
+            std::max(8, static_cast<int>(std::ceil(2 * M_PI * r / step)));
+        for (int k = 0; k < nSeg; k++)
+        {
+            const double a = 2 * M_PI * k / nSeg;
+            pts.emplace_back(r * std::cos(a), r * std::sin(a));
+        }
+    }
+    // std::monostate -> empty (legacy origin-only sampling)
+    return pts;
+}
+}  // namespace
+
 CostEvaluatorCostMap::Ptr CostEvaluatorCostMap::FromStaticPointObstacles(
     const mrpt::maps::CPointsMap&             obsPts,
     const CostEvaluatorCostMap::Parameters&   p,
-    const std::optional<mrpt::math::TPose2D>& curRobotPose)
+    const std::optional<mrpt::math::TPose2D>& curRobotPose,
+    const RobotShape&                         robotShape)
 {
     auto cm     = CostEvaluatorCostMap::Create();
     cm->params_ = p;
+
+    cm->shapeSamples_ = buildShapeSamples(robotShape, p.resolution);
 
     ASSERT_(!obsPts.empty());
 
@@ -173,8 +231,28 @@ double CostEvaluatorCostMap::operator()(const MoveEdgeSE2_TPS& edge) const
 double CostEvaluatorCostMap::eval_single_pose(
     const mrpt::math::TPose2D& p) const
 {
-    const double* cell = costmap_.cellByPos(p.x, p.y);
-    return cell ? *cell : .0;
+    // Legacy behavior: sample only the trajectory reference point.
+    if (shapeSamples_.empty())
+    {
+        const double* cell = costmap_.cellByPos(p.x, p.y);
+        return cell ? *cell : .0;
+    }
+
+    // Footprint-aware: max cost over the robot shape at this pose. The costmap
+    // cost decreases with distance to the nearest obstacle, so the maximum over
+    // the footprint boundary is the cost at the footprint point closest to an
+    // obstacle, i.e. the true clearance cost.
+    const double c       = std::cos(p.phi);
+    const double s       = std::sin(p.phi);
+    double       maxCost = .0;
+    for (const auto& v : shapeSamples_)
+    {
+        const double  wx   = p.x + v.x * c - v.y * s;
+        const double  wy   = p.y + v.x * s + v.y * c;
+        const double* cell = costmap_.cellByPos(wx, wy);
+        if (cell && *cell > maxCost) maxCost = *cell;
+    }
+    return maxCost;
 }
 
 mrpt::opengl::CSetOfObjects::Ptr CostEvaluatorCostMap::get_visualization() const

--- a/mrpt_path_planning/src/algos/NavEngine.cpp
+++ b/mrpt_path_planning/src/algos/NavEngine.cpp
@@ -745,7 +745,7 @@ NavEngine::PathPlannerOutput NavEngine::path_planner_function(
             planner.costEvaluators_.push_back(
                 mpp::CostEvaluatorCostMap::FromStaticPointObstacles(
                     *obs, config_.globalCostParameters,
-                    ppi.pi.stateStart.pose));
+                    ppi.pi.stateStart.pose, config_.ptgs.robotShape));
         }
     }
 
@@ -756,7 +756,8 @@ NavEngine::PathPlannerOutput NavEngine::path_planner_function(
         {
             planner.costEvaluators_.push_back(
                 mpp::CostEvaluatorCostMap::FromStaticPointObstacles(
-                    *obs, config_.localCostParameters, ppi.pi.stateStart.pose));
+                    *obs, config_.localCostParameters, ppi.pi.stateStart.pose,
+                    config_.ptgs.robotShape));
         }
     }
 

--- a/tests/test_costmap.cpp
+++ b/tests/test_costmap.cpp
@@ -16,7 +16,9 @@
 
 #include <gtest/gtest.h>
 #include <mpp/algos/CostEvaluatorCostMap.h>
+#include <mpp/data/MoveEdgeSE2_TPS.h>
 #include <mrpt/maps/CSimplePointsMap.h>
+#include <mrpt/math/TPolygon2D.h>
 
 #include <cmath>
 
@@ -110,6 +112,97 @@ TEST(CostMap, MonotonicallyDecreasingWithDistance)
             << ")";
         prevCost = c;
     }
+}
+
+// Single-pose edge whose reference point (stateFrom.pose) is `pose`, so that
+// operator() evaluates the (footprint) cost exactly at `pose`.
+namespace
+{
+mpp::MoveEdgeSE2_TPS makeSinglePoseEdge(const mrpt::math::TPose2D& pose)
+{
+    mpp::MoveEdgeSE2_TPS e;
+    e.stateFrom.pose    = pose;
+    e.estimatedExecTime = 1.0;
+    e.interpolatedPath[0.0] =
+        mrpt::math::TPose2D(0, 0, 0);  // relative to `from`
+    return e;
+}
+}  // namespace
+
+TEST(CostMap, ShapeSamplesEmptyByDefault)
+{
+    // No robot shape given -> legacy origin-only sampling.
+    auto cm = makeMapWithOneObstacle(0.0, 0.0);
+    EXPECT_TRUE(cm->shape_samples().empty());
+}
+
+TEST(CostMap, FootprintAwareVsOriginOnly)
+{
+    // Obstacle at the origin; clearance zone of 1 m.
+    auto pts = mrpt::maps::CSimplePointsMap::Create();
+    pts->insertPoint(0.0, 0.0, 0.0);
+
+    mpp::CostEvaluatorCostMap::Parameters p;
+    p.maxCost                    = 1.0;
+    p.preferredClearanceDistance = 1.0;
+    p.resolution                 = 0.05;
+
+    // Robot footprint: a rectangle extending forward (+x) 1 m ahead of the
+    // reference point, half-width 0.3 m.
+    mrpt::math::TPolygon2D shape;
+    shape.emplace_back(0.0, -0.3);
+    shape.emplace_back(1.0, -0.3);
+    shape.emplace_back(1.0, 0.3);
+    shape.emplace_back(0.0, 0.3);
+
+    auto cmOrigin =
+        mpp::CostEvaluatorCostMap::FromStaticPointObstacles(*pts, p);
+    auto cmShape = mpp::CostEvaluatorCostMap::FromStaticPointObstacles(
+        *pts, p, std::nullopt, mpp::RobotShape(shape));
+
+    EXPECT_FALSE(cmShape->shape_samples().empty());
+
+    // Reference point 1.2 m from the obstacle (beyond the 1 m clearance), but
+    // facing the obstacle (yaw=pi) so the footprint's front edge reaches to
+    // ~0.2 m from it.
+    const auto edge = makeSinglePoseEdge({1.2, 0.0, M_PI});
+
+    const double cOrigin = (*cmOrigin)(edge);
+    const double cShape  = (*cmShape)(edge);
+
+    EXPECT_NEAR(cOrigin, 0.0, 1e-9)
+        << "Origin-only: reference point is beyond the clearance distance";
+    EXPECT_GT(cShape, 0.4)
+        << "Footprint-aware: the front edge is well inside the clearance zone";
+    EXPECT_LE(cShape, p.maxCost + 1e-9);
+}
+
+TEST(CostMap, FootprintAwareFarAwayIsZero)
+{
+    // Same footprint, but far enough that not even the footprint reaches the
+    // clearance zone -> zero cost.
+    auto pts = mrpt::maps::CSimplePointsMap::Create();
+    pts->insertPoint(0.0, 0.0, 0.0);
+
+    mpp::CostEvaluatorCostMap::Parameters p;
+    p.maxCost                    = 1.0;
+    p.preferredClearanceDistance = 1.0;
+    p.resolution                 = 0.05;
+
+    mrpt::math::TPolygon2D shape;
+    shape.emplace_back(0.0, -0.3);
+    shape.emplace_back(1.0, -0.3);
+    shape.emplace_back(1.0, 0.3);
+    shape.emplace_back(0.0, 0.3);
+
+    auto cmShape = mpp::CostEvaluatorCostMap::FromStaticPointObstacles(
+        *pts, p, std::nullopt, mpp::RobotShape(shape));
+
+    // Facing away (+x), reference point at x=2.5: nearest footprint point is at
+    // x=2.5, well beyond the 1 m clearance.
+    const auto   edge   = makeSinglePoseEdge({2.5, 0.0, 0.0});
+    const double cShape = (*cmShape)(edge);
+    EXPECT_NEAR(cShape, 0.0, 1e-9);
 }
 
 TEST(CostMap, QuadraticDecay)


### PR DESCRIPTION
## Motivation

`CostEvaluatorCostMap` sampled its cost at the **trajectory reference point (base_link origin) only**. For non-point robots this means `preferredClearanceDistance` does **not** correspond to actual footprint clearance: a long or asymmetric footprint can graze an obstacle while the origin sits a full clearance-distance away. In practice the soft cost was nearly inert unless `maxCost` was inflated far above the edge travel-time cost.

Measured on a benchmark with a long (~1.75 m) footprint: the origin-only costmap at `(preferredClearanceDistance=0.75, maxCost=1.0)` produced paths **indistinguishable from having no costmap at all** (mean footprint clearance ~0.15 m, paths grazing the crop at 0.02–0.05 m).

## Change

`FromStaticPointObstacles()` gains an optional `RobotShape` argument. When a shape is supplied (polygon or radius), the per-edge cost is the **maximum costmap value over the robot footprint** transformed to each path pose, instead of a single origin sample. Sample points are precomputed once in the robot frame:

- **polygon**: vertices + points subdividing each edge finer than the costmap resolution (captures the side/corner closest to an obstacle);
- **radius**: a ring of points at that radius.

A `std::monostate` shape (the **default**) preserves the exact legacy origin-only behavior, so all existing callers compile and behave unchanged.

The cost is still the max over the footprint boundary, which for a soft-clearance term is what matters (the boundary point nearest an external obstacle sets the cost); hard collision remains checked separately against the full footprint.

## Wiring

Passed the robot shape (`config_.ptgs.robotShape` / `pi.ptgs.robotShape`) at the library's own call sites:
- `NavEngine` (global + local costmaps),
- `path-planner-cli` (PTG init moved above the costmap so the shape is available),
- `selfdriving-simulator-gui` (static + lidar costmaps).

## Tests

`tests/test_costmap.cpp` adds:
- `ShapeSamplesEmptyByDefault` — origin-only when no shape given;
- `FootprintAwareVsOriginOnly` — origin beyond clearance ⇒ 0 cost, but a footprint reaching into the clearance zone ⇒ high cost;
- `FootprintAwareFarAwayIsZero` — footprint fully outside the clearance zone ⇒ 0 cost.

All 8 costmap tests pass.

## Result

With footprint-awareness, `preferredClearanceDistance` maps to real clearance again: on the same benchmark, `(0.75, 2.0)` footprint-aware reaches the same ~0.35 m real footprint clearance that origin-only sampling needed `(1.5, 4.0)` to reach — at half the clearance distance and half the penalty — while keeping paths smooth. Extra cost is a precomputed set of grid lookups per edge; plan time stays in the tens of milliseconds on the benchmark.

## Notes / follow-ups

- Fully backward compatible (defaulted argument).
- ROS consumers (e.g. `mrpt_tps_astar_planner` node) need a one-line change to pass their robot shape to benefit; happy to follow up there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved obstacle-cost evaluation to account for the robot’s full footprint, not just its reference point.
  * Added footprint-aware clearance handling for polygonal and circular robot shapes.
  * Added access to calculated footprint sampling points for visualization and validation.

* **Bug Fixes**
  * Improved path planning accuracy near obstacles by detecting collisions and clearance risks across the robot’s body.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->