### PR TITLE
feat(follow): TrajectoryFollower with predictive safety

### DIFF
--- a/mrpt_path_planning/CMakeLists.txt
+++ b/mrpt_path_planning/CMakeLists.txt
@@ -24,6 +24,7 @@ set(LIB_SRCS
 	src/data/MoveEdgeSE2_TPS.cpp
 	src/data/PlannerInput.cpp
 	src/data/PlannerOutput.cpp
+	src/data/robot_shape_sampling.cpp
 	src/data/SE2_KinState.cpp
 	src/data/TrajectoriesAndRobotShape.cpp
 	src/data/Waypoints.cpp
@@ -66,6 +67,7 @@ set(LIB_PUBLIC_HDRS
 	include/mpp/data/ProgressCallbackData.h
 	include/mpp/data/ptg_t.h
 	include/mpp/data/RenderOptions.h
+	include/mpp/data/robot_shape_sampling.h
 	include/mpp/data/SE2_KinState.h
 	include/mpp/data/TrajectoriesAndRobotShape.h
 	include/mpp/data/trajectory_t.h

--- a/mrpt_path_planning/CMakeLists.txt
+++ b/mrpt_path_planning/CMakeLists.txt
@@ -1,7 +1,91 @@
 project(mrpt_path_planning LANGUAGES CXX)
 
-file(GLOB_RECURSE LIB_SRCS src/*.cpp src/*.h)
-file(GLOB_RECURSE LIB_PUBLIC_HDRS include/*.h)
+# Explicit source/header lists (kept in sync by hand rather than globbed, so
+# that adding/removing a file is a visible, reviewable change and reliably
+# re-triggers CMake configure).
+set(LIB_SRCS
+	src/algos/bestTrajectory.cpp
+	src/algos/CostEvaluator.cpp
+	src/algos/CostEvaluatorCostMap.cpp
+	src/algos/CostEvaluatorPreferredWaypoint.cpp
+	src/algos/edge_interpolated_path.cpp
+	src/algos/NavEngine.cpp
+	src/algos/Planner.cpp
+	src/algos/refine_trajectory.cpp
+	src/algos/render_tree.cpp
+	src/algos/render_vehicle.cpp
+	src/algos/tp_obstacles_single_path.cpp
+	src/algos/TPS_Astar.cpp
+	src/algos/TPS_Astar_Bidir.cpp
+	src/algos/trajectories.cpp
+	src/algos/transform_pc_square_clipping.cpp
+	src/algos/viz.cpp
+	src/algos/viz_svg.cpp
+	src/data/MoveEdgeSE2_TPS.cpp
+	src/data/PlannerInput.cpp
+	src/data/PlannerOutput.cpp
+	src/data/SE2_KinState.cpp
+	src/data/TrajectoriesAndRobotShape.cpp
+	src/data/Waypoints.cpp
+	src/follow/algos/TrajectoryFollower.cpp
+	src/interfaces/ObstacleSource.cpp
+	src/interfaces/TargetApproachController.cpp
+	src/interfaces/VehicleMotionInterface.cpp
+	src/ptgs/DiffDrive_C.cpp
+	src/ptgs/DiffDriveCollisionGridBased.cpp
+	src/ptgs/HolonomicBlend.cpp
+	src/registerClasses.cpp
+)
+
+set(LIB_PUBLIC_HDRS
+	include/mpp/algos/bestTrajectory.h
+	include/mpp/algos/CostEvaluator.h
+	include/mpp/algos/CostEvaluatorCostMap.h
+	include/mpp/algos/CostEvaluatorPreferredWaypoint.h
+	include/mpp/algos/edge_interpolated_path.h
+	include/mpp/algos/NavEngine.h
+	include/mpp/algos/Planner.h
+	include/mpp/algos/refine_trajectory.h
+	include/mpp/algos/render_tree.h
+	include/mpp/algos/render_vehicle.h
+	include/mpp/algos/tp_obstacles_single_path.h
+	include/mpp/algos/TPS_Astar.h
+	include/mpp/algos/TPS_Astar_Bidir.h
+	include/mpp/algos/trajectories.h
+	include/mpp/algos/transform_pc_square_clipping.h
+	include/mpp/algos/viz.h
+	include/mpp/algos/viz_svg.h
+	include/mpp/algos/within_bbox.h
+	include/mpp/data/basic_types.h
+	include/mpp/data/const_ref_t.h
+	include/mpp/data/EnqueuedMotionCmd.h
+	include/mpp/data/MotionPrimitivesTree.h
+	include/mpp/data/MoveEdgeSE2_TPS.h
+	include/mpp/data/PlannerInput.h
+	include/mpp/data/PlannerOutput.h
+	include/mpp/data/ProgressCallbackData.h
+	include/mpp/data/ptg_t.h
+	include/mpp/data/RenderOptions.h
+	include/mpp/data/SE2_KinState.h
+	include/mpp/data/TrajectoriesAndRobotShape.h
+	include/mpp/data/trajectory_t.h
+	include/mpp/data/VehicleLocalizationState.h
+	include/mpp/data/VehicleOdometryState.h
+	include/mpp/data/Waypoints.h
+	include/mpp/follow/algos/TrajectoryFollower.h
+	include/mpp/follow/data/SampledTrajectory.h
+	include/mpp/follow/data/Trajectory.h
+	include/mpp/follow/interfaces/TrajectoryVehicleInterface.h
+	include/mpp/interfaces/LidarSource.h
+	include/mpp/interfaces/MVSIM_VehicleInterface.h
+	include/mpp/interfaces/ObstacleSource.h
+	include/mpp/interfaces/TargetApproachController.h
+	include/mpp/interfaces/VehicleMotionInterface.h
+	include/mpp/ptgs/DiffDrive_C.h
+	include/mpp/ptgs/DiffDriveCollisionGridBased.h
+	include/mpp/ptgs/HolonomicBlend.h
+	include/mpp/ptgs/SpeedTrimmablePTG.h
+)
 
 # define lib:
 selfdriving_add_library(

--- a/mrpt_path_planning/include/mpp/data/robot_shape_sampling.h
+++ b/mrpt_path_planning/include/mpp/data/robot_shape_sampling.h
@@ -1,0 +1,31 @@
+/* -------------------------------------------------------------------------
+ *   SelfDriving C++ library based on PTGs and mrpt-nav
+ * Copyright (C) 2019-2026 Jose Luis Blanco, University of Almeria
+ * See LICENSE for license information.
+ * ------------------------------------------------------------------------- */
+
+#pragma once
+
+#include <mpp/data/TrajectoriesAndRobotShape.h>  // RobotShape
+#include <mrpt/math/TPoint2D.h>
+
+#include <cstddef>
+#include <vector>
+
+namespace mpp
+{
+/** Builds a set of robot-frame points sampling the robot footprint boundary.
+ *
+ * For a polygon: its vertices plus points subdividing each edge no coarser than
+ * `resolution`. For a radius: a ring of points at that radius. For a
+ * `std::monostate` shape: an empty vector (caller decides the fallback, e.g.
+ * sampling only the reference point).
+ *
+ * The total number of samples is capped at `maxSamples`: sampling finer than
+ * `resolution` is wasted, and for very large footprints the perimeter step is
+ * coarsened to keep the count bounded (this may run on hot paths).
+ */
+std::vector<mrpt::math::TPoint2D> footprintSamplePoints(
+    const RobotShape& shape, double resolution, std::size_t maxSamples = 128);
+
+}  // namespace mpp

--- a/mrpt_path_planning/include/mpp/follow/algos/TrajectoryFollower.h
+++ b/mrpt_path_planning/include/mpp/follow/algos/TrajectoryFollower.h
@@ -1,0 +1,158 @@
+/* -------------------------------------------------------------------------
+ *   SelfDriving C++ library based on PTGs and mrpt-nav
+ * Copyright (C) 2019-2026 Jose Luis Blanco, University of Almeria
+ * See LICENSE for license information.
+ * ------------------------------------------------------------------------- */
+
+#pragma once
+
+#include <mpp/data/VehicleLocalizationState.h>
+#include <mpp/data/VehicleOdometryState.h>
+#include <mpp/follow/data/SampledTrajectory.h>
+#include <mpp/follow/data/Trajectory.h>
+#include <mrpt/containers/yaml.h>
+#include <mrpt/core/bits_math.h>
+#include <mrpt/math/TPoint2D.h>
+#include <mrpt/system/COutputLogger.h>
+
+#include <cstdint>
+#include <vector>
+
+namespace mpp
+{
+enum class FollowerStatus : uint8_t
+{
+    /** No trajectory set, or fewer than 2 points. */
+    Idle,
+    /** Tracking normally. */
+    Running,
+    /** Final point reached within tolerance. */
+    ReachedGoal,
+    /** Stopped by the predictive safety layer beyond the block timeout (added
+     * in the safety stage; never emitted by the pursuit core alone). */
+    Blocked,
+    /** Cross-track error exceeded the configured limit. */
+    OffPathExceeded
+};
+
+/** Pure-pursuit trajectory follower core (ROS-free, no safety yet).
+ *
+ * Consumes a planner-agnostic pose+speed polyline (\ref Trajectory) and, each
+ * control cycle, emits a short rolling \ref SampledTrajectory (the motion it
+ * wants the robot to make over the next horizon) plus a status. Timing is
+ * *spatial*: the polyline's speeds are caps along arc-length, never a schedule
+ * to catch up to, so later safety slow-downs never cause rushing.
+ *
+ * Feedback: path progress is measured on the map-frame localization; the
+ * emitted chunk is expressed in the odom frame (via the current map->odom
+ * correction) so relocalization jumps do not lurch the wheels.
+ *
+ * This is the pursuit + speed-profile + events core. The predictive safety
+ * layer (speed-scale/stop/resume) and the mvsim benchmark are added on top.
+ */
+class TrajectoryFollower : public mrpt::system::COutputLogger
+{
+   public:
+    TrajectoryFollower();
+    ~TrajectoryFollower() = default;
+
+    struct Parameters
+    {
+        double max_speed         = 0.5;  //!< [m/s]
+        double max_accel         = 0.5;  //!< [m/s^2]
+        double max_decel         = 0.7;  //!< [m/s^2] (goal + speed reductions)
+        double max_lateral_accel = 1.0;  //!< [m/s^2] curvature speed limit
+
+        /** Lookahead distance L = clamp(lookahead_time * v, min, max) [m,s]. */
+        double lookahead_min  = 0.4;
+        double lookahead_max  = 1.5;
+        double lookahead_time = 1.0;
+
+        double goal_dist_tol   = 0.15;  //!< [m]
+        double goal_ang_tol    = mrpt::DEG2RAD(12.0);  //!< [rad]
+        double max_cross_track = 1.0;  //!< [m] OffPathExceeded
+
+        double control_period = 0.05;  //!< [s] nominal call period (20 Hz)
+        double horizon        = 1.5;  //!< [s] emitted chunk length
+        double sample_period  = 0.1;  //!< [s] emitted chunk sampling
+
+        std::string emit_frame = "odom";  //!< frame of the emitted chunk
+
+        static Parameters      FromYAML(const mrpt::containers::yaml& c);
+        mrpt::containers::yaml as_yaml() const;
+        void                   load_from_yaml(const mrpt::containers::yaml& c);
+    };
+
+    Parameters params;
+
+    /** Sets/replaces the reference path (hot-swappable at any time); resets
+     * arc-length progress. Needs >= 2 points to track. */
+    void setTrajectory(const Trajectory& traj);
+
+    /** Clears the trajectory and progress. */
+    void reset();
+
+    bool   hasTrajectory() const { return traj_.size() >= 2; }
+    double totalLength() const { return cumS_.empty() ? 0.0 : cumS_.back(); }
+
+    struct Output
+    {
+        SampledTrajectory
+            command;  //!< hand to TrajectoryVehicleInterface::follow()
+        FollowerStatus status = FollowerStatus::Idle;
+
+        // Debug / introspection:
+        double               arc_length_s    = 0;
+        double               cross_track_err = 0;  //!< signed [m]
+        double               heading_err     = 0;  //!< [rad]
+        double               target_speed    = 0;  //!< [m/s] immediate command
+        mrpt::math::TPoint2D lookahead_point{0, 0};
+    };
+
+    /** One control cycle: given the latest localization (map) and odometry
+     * (odom), computes and returns the command chunk + status. Does not itself
+     * call the vehicle interface; the node does `iface.follow(out.command)` (or
+     * `iface.stop()` on ReachedGoal). */
+    Output step(
+        const VehicleLocalizationState& loc, const VehicleOdometryState& odo);
+
+   private:
+    Trajectory          traj_;
+    std::vector<double> cumS_;  //!< cumulative arc-length per point
+    double              lastS_ = 0;  //!< monotonic progress (map projection)
+
+    struct Projection
+    {
+        double s            = 0;  //!< arc-length of nearest point
+        double cross_track  = 0;  //!< signed lateral error [m]
+        double path_heading = 0;  //!< tangent heading [rad]
+    };
+
+    /** Nearest point on the polyline to `xy`, searching forward from `sHint`.
+     * Pure (no state mutation). */
+    Projection projectToPath(
+        const mrpt::math::TPoint2D& xy, double sHint) const;
+
+    /** Path point (x,y) at arc-length `s` (clamped to [0, total]). */
+    mrpt::math::TPoint2D pointAtArc(double s) const;
+
+    /** Interpolated speed cap at arc-length `s` (<=0 entries treated as
+     * max_speed). */
+    double speedCapAt(double s) const;
+
+    struct Command
+    {
+        double               v     = 0;  //!< [m/s]
+        double               omega = 0;  //!< [rad/s]
+        mrpt::math::TPoint2D lookahead{0, 0};
+    };
+
+    /** Pure-pursuit command at `fromPose` given `currentV`, advancing the
+     * lookahead from projection near `sHint`. `dt` bounds the accel/decel step.
+     */
+    Command pursuit(
+        const mrpt::math::TPose2D& fromPose, double currentV, double sHint,
+        double dt) const;
+};
+
+}  // namespace mpp

--- a/mrpt_path_planning/include/mpp/follow/algos/TrajectoryFollower.h
+++ b/mrpt_path_planning/include/mpp/follow/algos/TrajectoryFollower.h
@@ -6,12 +6,14 @@
 
 #pragma once
 
+#include <mpp/data/TrajectoriesAndRobotShape.h>  // RobotShape
 #include <mpp/data/VehicleLocalizationState.h>
 #include <mpp/data/VehicleOdometryState.h>
 #include <mpp/follow/data/SampledTrajectory.h>
 #include <mpp/follow/data/Trajectory.h>
 #include <mrpt/containers/yaml.h>
 #include <mrpt/core/bits_math.h>
+#include <mrpt/maps/CSimplePointsMap.h>
 #include <mrpt/math/TPoint2D.h>
 #include <mrpt/system/COutputLogger.h>
 
@@ -35,7 +37,7 @@ enum class FollowerStatus : uint8_t
     OffPathExceeded
 };
 
-/** Pure-pursuit trajectory follower core (ROS-free, no safety yet).
+/** Pure-pursuit trajectory follower core with predictive safety (ROS-free).
  *
  * Consumes a planner-agnostic pose+speed polyline (\ref Trajectory) and, each
  * control cycle, emits a short rolling \ref SampledTrajectory (the motion it
@@ -47,8 +49,12 @@ enum class FollowerStatus : uint8_t
  * emitted chunk is expressed in the odom frame (via the current map->odom
  * correction) so relocalization jumps do not lurch the wheels.
  *
- * This is the pursuit + speed-profile + events core. The predictive safety
- * layer (speed-scale/stop/resume) and the mvsim benchmark are added on top.
+ * Predictive safety: if a robot footprint and live obstacle points are set
+ * (\ref setRobotShape / \ref setObstacles), each cycle the follower sweeps the
+ * footprint over both its own forecast rollout and the upcoming reference
+ * segment, and scales the commanded speed down (to a full stop before contact),
+ * resuming automatically when the way clears. With no footprint or no obstacles
+ * this layer is inert and the follower behaves as a plain pursuit core.
  */
 class TrajectoryFollower : public mrpt::system::COutputLogger
 {
@@ -78,6 +84,42 @@ class TrajectoryFollower : public mrpt::system::COutputLogger
 
         std::string emit_frame = "odom";  //!< frame of the emitted chunk
 
+        // --- Predictive safety (inert unless a footprint + obstacles are set)
+        // ---
+
+        /** [m] Footprint clearance at or below which a swept pose counts as a
+         * predicted contact (a small inflation of the footprint). */
+        double safety_margin = 0.05;
+
+        /** [m] If the nearest predicted contact is within this travel distance,
+         * command a full stop (speed scale 0). */
+        double stop_distance = 0.3;
+
+        /** [m] If the nearest predicted contact is beyond this travel distance,
+         * do not slow down at all (speed scale 1). Linear scaling in between.
+         */
+        double slow_distance = 1.5;
+
+        /** [s] How far ahead to roll out the command forecast for the safety
+         * sweep. */
+        double safety_horizon = 3.0;
+
+        /** [m] How far ahead along the reference path to sweep the footprint.
+         */
+        double reference_lookahead_dist = 2.5;
+
+        /** [m] Step used to sample the footprint boundary and to march the
+         * reference sweep. */
+        double footprint_sample_resolution = 0.1;
+
+        /** Speed scale that must be recovered before resuming after a safety
+         * stop (hysteresis to avoid chattering). */
+        double resume_scale = 0.2;
+
+        /** [s] If held stopped by the safety layer longer than this, report
+         * `Blocked`. */
+        double block_timeout = 5.0;
+
         static Parameters      FromYAML(const mrpt::containers::yaml& c);
         mrpt::containers::yaml as_yaml() const;
         void                   load_from_yaml(const mrpt::containers::yaml& c);
@@ -91,6 +133,17 @@ class TrajectoryFollower : public mrpt::system::COutputLogger
 
     /** Clears the trajectory and progress. */
     void reset();
+
+    /** Sets the robot footprint used by the predictive safety sweeps (polygon,
+     * radius, or `std::monostate` to sample only the reference point). */
+    void setRobotShape(const RobotShape& shape);
+
+    /** Sets/replaces the live obstacle points (map frame) used by the
+     * predictive safety sweeps. An empty cloud disables safety scaling. */
+    void setObstacles(const mrpt::maps::CPointsMap& obstacles);
+
+    /** Convenience overload: obstacle points as (x,y) in the map frame. */
+    void setObstacles(const std::vector<mrpt::math::TPoint2D>& obstacles);
 
     bool   hasTrajectory() const { return traj_.size() >= 2; }
     double totalLength() const { return cumS_.empty() ? 0.0 : cumS_.back(); }
@@ -107,6 +160,10 @@ class TrajectoryFollower : public mrpt::system::COutputLogger
         double               heading_err     = 0;  //!< [rad]
         double               target_speed    = 0;  //!< [m/s] immediate command
         mrpt::math::TPoint2D lookahead_point{0, 0};
+
+        /** Safety speed scale applied this cycle (1 = unrestricted, 0 = stopped
+         * by the predictive safety layer). */
+        double safety_scale = 1.0;
     };
 
     /** One control cycle: given the latest localization (map) and odometry
@@ -120,6 +177,13 @@ class TrajectoryFollower : public mrpt::system::COutputLogger
     Trajectory          traj_;
     std::vector<double> cumS_;  //!< cumulative arc-length per point
     double              lastS_ = 0;  //!< monotonic progress (map projection)
+
+    // Predictive safety state:
+    std::vector<mrpt::math::TPoint2D>
+                                 shapeSamples_;  //!< footprint, robot frame
+    mrpt::maps::CSimplePointsMap obstacles_;  //!< map frame (kd-tree)
+    bool stopped_ = false;  //!< safety-stop hysteresis latch
+    mrpt::system::TTimeStamp stoppedSince_ = INVALID_TIMESTAMP;
 
     struct Projection
     {
@@ -149,10 +213,34 @@ class TrajectoryFollower : public mrpt::system::COutputLogger
 
     /** Pure-pursuit command at `fromPose` given `currentV`, advancing the
      * lookahead from projection near `sHint`. `dt` bounds the accel/decel step.
+     * `speedScale` (0..1) caps the target speed before rate-limiting (safety).
      */
     Command pursuit(
         const mrpt::math::TPose2D& fromPose, double currentV, double sHint,
-        double dt) const;
+        double dt, double speedScale = 1.0) const;
+
+    /** Pose (x,y + tangent heading) on the reference polyline at arc-length
+     * `s`. */
+    mrpt::math::TPose2D poseAtArc(double s) const;
+
+    /** Min distance from the footprint (at map-frame pose `p`) to the nearest
+     * obstacle point; +inf if no obstacles are set. */
+    double footprintClearance(const mrpt::math::TPose2D& p) const;
+
+    /** Rolls the command forecast forward from `startPose` (map frame) and
+     * returns the travel distance to the first predicted footprint contact;
+     * +inf if none within `safety_horizon`. */
+    double forecastContactDistance(
+        const mrpt::math::TPose2D& startPose, double startV,
+        double startS) const;
+
+    /** Sweeps the footprint along the reference path ahead of `startS` and
+     * returns the travel distance to the first predicted contact; +inf if none
+     * within `reference_lookahead_dist`. */
+    double referenceContactDistance(double startS) const;
+
+    /** Maps a nearest-contact travel distance to a [0,1] speed scale. */
+    double contactDistanceToScale(double d) const;
 };
 
 }  // namespace mpp

--- a/mrpt_path_planning/include/mpp/follow/algos/TrajectoryFollower.h
+++ b/mrpt_path_planning/include/mpp/follow/algos/TrajectoryFollower.h
@@ -178,6 +178,11 @@ class TrajectoryFollower : public mrpt::system::COutputLogger
     std::vector<double> cumS_;  //!< cumulative arc-length per point
     double              lastS_ = 0;  //!< monotonic progress (map projection)
 
+    /** Last commanded speed [m/s]. The feedforward speed ramp is rate-limited
+     * from this internal state (not from measured odometry velocity), so the
+     * profile still accelerates when the odometry source reports no twist. */
+    double lastCommandedSpeed_ = 0;
+
     // Predictive safety state:
     std::vector<mrpt::math::TPoint2D>
                                  shapeSamples_;  //!< footprint, robot frame

--- a/mrpt_path_planning/include/mpp/follow/data/SampledTrajectory.h
+++ b/mrpt_path_planning/include/mpp/follow/data/SampledTrajectory.h
@@ -1,0 +1,55 @@
+/* -------------------------------------------------------------------------
+ *   SelfDriving C++ library based on PTGs and mrpt-nav
+ * Copyright (C) 2019-2026 Jose Luis Blanco, University of Almeria
+ * See LICENSE for license information.
+ * ------------------------------------------------------------------------- */
+
+#pragma once
+
+#include <mrpt/math/TPose2D.h>
+#include <mrpt/math/TTwist2D.h>
+#include <mrpt/system/datetime.h>
+
+#include <string>
+#include <vector>
+
+namespace mpp
+{
+/** One sample of the short rolling reference the follower hands to the vehicle
+ * interface to execute. */
+struct TrajSample
+{
+    /** [s] Time from the parent SampledTrajectory `stamp` (t=0 at the sample
+     * the robot should be executing "now"). */
+    double t = 0;
+
+    /** Desired pose, expressed in the parent's `frame_id`. */
+    mrpt::math::TPose2D pose;
+
+    /** Desired body-frame velocity (vx, vy, omega). Frame-invariant. */
+    mrpt::math::TTwist2D twist;
+
+    /** Safety speed factor applied to this sample (1 = full profile speed, 0 =
+     * commanded stop). For debugging / visualization. */
+    double speed_scale = 1.0;
+};
+
+/** A short-horizon, safety-scaled predicted trajectory: the exact motion the
+ * follower wants the robot to make over the next horizon. It is simultaneously
+ * the command to execute, the rollout the safety check sweeps, and a
+ * self-expiring latency buffer (each sample is time-stamped). */
+struct SampledTrajectory
+{
+    /** Frame the sample poses are expressed in (e.g. "odom"). */
+    std::string frame_id;
+
+    /** Wall time of t=0. */
+    mrpt::system::TTimeStamp stamp = INVALID_TIMESTAMP;
+
+    /** Samples, in strictly increasing `t`. */
+    std::vector<TrajSample> points;
+
+    bool empty() const { return points.empty(); }
+};
+
+}  // namespace mpp

--- a/mrpt_path_planning/include/mpp/follow/data/Trajectory.h
+++ b/mrpt_path_planning/include/mpp/follow/data/Trajectory.h
@@ -1,0 +1,37 @@
+/* -------------------------------------------------------------------------
+ *   SelfDriving C++ library based on PTGs and mrpt-nav
+ * Copyright (C) 2019-2026 Jose Luis Blanco, University of Almeria
+ * See LICENSE for license information.
+ * ------------------------------------------------------------------------- */
+
+#pragma once
+
+#include <mrpt/math/TPose2D.h>
+
+#include <vector>
+
+namespace mpp
+{
+/** One point of a reference path for the TrajectoryFollower: a pose plus a
+ * desired speed cap at that point. */
+struct RefPoint
+{
+    RefPoint() = default;
+    RefPoint(const mrpt::math::TPose2D& p, double v) : pose(p), target_speed(v)
+    {
+    }
+
+    mrpt::math::TPose2D pose;
+
+    /** [m/s] Desired speed cap along the arc-length at this point. A value <= 0
+     * means "unspecified": the follower uses its configured max speed. */
+    double target_speed = 0;
+};
+
+/** A planner-agnostic reference path: a pose+speed polyline, interpolated by
+ * arc-length. It is *not* required to be kinematically feasible: the follower's
+ * pure-pursuit law smooths over it. Any source (a planner, a recording, a
+ * hand-drawn path) can produce one. */
+using Trajectory = std::vector<RefPoint>;
+
+}  // namespace mpp

--- a/mrpt_path_planning/include/mpp/follow/interfaces/TrajectoryVehicleInterface.h
+++ b/mrpt_path_planning/include/mpp/follow/interfaces/TrajectoryVehicleInterface.h
@@ -1,0 +1,65 @@
+/* -------------------------------------------------------------------------
+ *   SelfDriving C++ library based on PTGs and mrpt-nav
+ * Copyright (C) 2019-2026 Jose Luis Blanco, University of Almeria
+ * See LICENSE for license information.
+ * ------------------------------------------------------------------------- */
+
+#pragma once
+
+#include <mpp/data/VehicleLocalizationState.h>
+#include <mpp/data/VehicleOdometryState.h>
+#include <mpp/follow/data/SampledTrajectory.h>
+#include <mrpt/system/COutputLogger.h>
+
+#include <chrono>
+#include <cstdint>
+
+namespace mpp
+{
+enum class StopKind : uint8_t
+{
+    REGULAR = 0,
+    EMERGENCY
+};
+
+/** The ROS-free boundary between the TrajectoryFollower and a real platform.
+ *
+ * Unlike the older `VehicleMotionInterface` (PTG immediate/next command slots),
+ * this interface is served a short **sampled predicted trajectory** to execute:
+ * the follower has already closed the loop on localization, so the platform
+ * side only needs a thin, fast inner servo that tracks the handed chunk
+ * (feedforward `twist` + a small pose feedback) until the next one arrives.
+ *
+ * The kinematic model is not assumed here: it lives in the PTGs the follower
+ * uses to shape commands, so this works for Ackermann / differential /
+ * holonomic robots alike.
+ */
+class TrajectoryVehicleInterface : public mrpt::system::COutputLogger
+{
+   public:
+    TrajectoryVehicleInterface()
+        : mrpt::system::COutputLogger("TrajectoryVehicleInterface")
+    {
+    }
+    virtual ~TrajectoryVehicleInterface() = default;
+
+    /** Latest global localization (map frame). Leave `valid=false` on error. */
+    virtual VehicleLocalizationState get_localization() = 0;
+
+    /** Latest odometry (odom frame) + local velocity. Leave `valid=false` on
+     * error. */
+    virtual VehicleOdometryState get_odometry() = 0;
+
+    /** Execute/track this short reference; it supersedes any previous one. An
+     * empty trajectory means a controlled stop. Resets the watchdog. */
+    virtual void follow(const SampledTrajectory& ref) = 0;
+
+    /** Immediate stop request (regular or emergency). */
+    virtual void stop(StopKind kind) = 0;
+
+    /** Arm a watchdog: if neither follow() nor stop() is called within
+     * `timeout`, the platform must stop the robot. */
+    virtual void start_watchdog(std::chrono::milliseconds timeout) = 0;
+};
+
+}  // namespace mpp

--- a/mrpt_path_planning/src/algos/CostEvaluatorCostMap.cpp
+++ b/mrpt_path_planning/src/algos/CostEvaluatorCostMap.cpp
@@ -5,6 +5,7 @@
  * ------------------------------------------------------------------------- */
 
 #include <mpp/algos/CostEvaluatorCostMap.h>
+#include <mpp/data/robot_shape_sampling.h>
 #include <mrpt/img/color_maps.h>
 #include <mrpt/maps/COccupancyGridMap2D.h>
 #include <mrpt/opengl/CTexturedPlane.h>
@@ -54,75 +55,6 @@ void CostEvaluatorCostMap::Parameters::load_from_yaml(
 
 CostEvaluatorCostMap::~CostEvaluatorCostMap() = default;
 
-namespace
-{
-// Builds the set of robot-frame points at which the footprint cost is sampled.
-// For a polygon: its vertices plus points subdividing each edge finer than the
-// costmap resolution, so the max cost picks up the footprint side/corner
-// closest to an obstacle. For a radius: a ring of points at that radius. The
-// maximum costmap value over these points (transformed to a path pose) then
-// reflects the true footprint clearance, not just the reference-point
-// clearance.
-//
-// This runs on the cost-evaluation hot path (per interpolated pose, per edge),
-// so the total sample count is capped: sampling finer than the costmap
-// resolution is wasted (adjacent samples fall in the same cell), and for very
-// large footprints the perimeter step is coarsened to keep the count bounded.
-std::vector<mrpt::math::TPoint2D> buildShapeSamples(
-    const mpp::RobotShape& shape, double resolution)
-{
-    constexpr size_t MAX_SAMPLES = 128;
-
-    std::vector<mrpt::math::TPoint2D> pts;
-    const double                      res = std::max(0.01, resolution);
-
-    if (const auto* poly = std::get_if<mrpt::math::TPolygon2D>(&shape))
-    {
-        const auto&  v = *poly;
-        const size_t n = v.size();
-        if (n < 2) return pts;
-
-        double perimeter = 0;
-        for (size_t i = 0; i < n; i++)
-            perimeter += (v[(i + 1) % n] - v[i]).norm();
-
-        // Step at the grid resolution, coarsened if needed to stay under the
-        // cap.
-        const double step = std::max(res, perimeter / MAX_SAMPLES);
-
-        for (size_t i = 0; i < n; i++)
-        {
-            const auto&  a   = v[i];
-            const auto&  b   = v[(i + 1) % n];
-            const double len = std::hypot(b.x - a.x, b.y - a.y);
-            const int    nSeg =
-                std::max(1, static_cast<int>(std::ceil(len / step)));
-            for (int k = 0; k < nSeg;
-                 k++)  // include a, exclude b (next edge's a)
-            {
-                const double t = static_cast<double>(k) / nSeg;
-                pts.emplace_back(a.x + t * (b.x - a.x), a.y + t * (b.y - a.y));
-            }
-        }
-    }
-    else if (const auto* radius = std::get_if<mpp::robot_radius_t>(&shape))
-    {
-        const double r = *radius;
-        if (r <= 0) return pts;
-        const double step = std::max(res, 2 * M_PI * r / MAX_SAMPLES);
-        const int    nSeg =
-            std::max(8, static_cast<int>(std::ceil(2 * M_PI * r / step)));
-        for (int k = 0; k < nSeg; k++)
-        {
-            const double a = 2 * M_PI * k / nSeg;
-            pts.emplace_back(r * std::cos(a), r * std::sin(a));
-        }
-    }
-    // std::monostate -> empty (legacy origin-only sampling)
-    return pts;
-}
-}  // namespace
-
 CostEvaluatorCostMap::Ptr CostEvaluatorCostMap::FromStaticPointObstacles(
     const mrpt::maps::CPointsMap&             obsPts,
     const CostEvaluatorCostMap::Parameters&   p,
@@ -132,7 +64,7 @@ CostEvaluatorCostMap::Ptr CostEvaluatorCostMap::FromStaticPointObstacles(
     auto cm     = CostEvaluatorCostMap::Create();
     cm->params_ = p;
 
-    cm->shapeSamples_ = buildShapeSamples(robotShape, p.resolution);
+    cm->shapeSamples_ = footprintSamplePoints(robotShape, p.resolution);
 
     ASSERT_(!obsPts.empty());
 

--- a/mrpt_path_planning/src/data/robot_shape_sampling.cpp
+++ b/mrpt_path_planning/src/data/robot_shape_sampling.cpp
@@ -1,0 +1,62 @@
+/* -------------------------------------------------------------------------
+ *   SelfDriving C++ library based on PTGs and mrpt-nav
+ * Copyright (C) 2019-2026 Jose Luis Blanco, University of Almeria
+ * See LICENSE for license information.
+ * ------------------------------------------------------------------------- */
+
+#include <mpp/data/robot_shape_sampling.h>
+
+#include <algorithm>
+#include <cmath>
+
+std::vector<mrpt::math::TPoint2D> mpp::footprintSamplePoints(
+    const RobotShape& shape, double resolution, std::size_t maxSamples)
+{
+    std::vector<mrpt::math::TPoint2D> pts;
+    const double                      res = std::max(0.01, resolution);
+
+    if (const auto* poly = std::get_if<mrpt::math::TPolygon2D>(&shape))
+    {
+        const auto&       v = *poly;
+        const std::size_t n = v.size();
+        if (n < 2) return pts;
+
+        double perimeter = 0;
+        for (std::size_t i = 0; i < n; i++)
+            perimeter += (v[(i + 1) % n] - v[i]).norm();
+
+        // Step at the grid resolution, coarsened if needed to stay under the
+        // cap.
+        const double step = std::max(res, perimeter / maxSamples);
+
+        for (std::size_t i = 0; i < n; i++)
+        {
+            const auto&  a   = v[i];
+            const auto&  b   = v[(i + 1) % n];
+            const double len = std::hypot(b.x - a.x, b.y - a.y);
+            const int    nSeg =
+                std::max(1, static_cast<int>(std::ceil(len / step)));
+            for (int k = 0; k < nSeg;
+                 k++)  // include a, exclude b (next edge's a)
+            {
+                const double t = static_cast<double>(k) / nSeg;
+                pts.emplace_back(a.x + t * (b.x - a.x), a.y + t * (b.y - a.y));
+            }
+        }
+    }
+    else if (const auto* radius = std::get_if<mpp::robot_radius_t>(&shape))
+    {
+        const double r = *radius;
+        if (r <= 0) return pts;
+        const double step = std::max(res, 2 * M_PI * r / maxSamples);
+        const int    nSeg =
+            std::max(8, static_cast<int>(std::ceil(2 * M_PI * r / step)));
+        for (int k = 0; k < nSeg; k++)
+        {
+            const double a = 2 * M_PI * k / nSeg;
+            pts.emplace_back(r * std::cos(a), r * std::sin(a));
+        }
+    }
+    // std::monostate -> empty
+    return pts;
+}

--- a/mrpt_path_planning/src/follow/algos/TrajectoryFollower.cpp
+++ b/mrpt_path_planning/src/follow/algos/TrajectoryFollower.cpp
@@ -122,18 +122,20 @@ void TrajectoryFollower::setTrajectory(const Trajectory& traj)
         const auto& b = traj_[i].pose;
         cumS_[i]      = cumS_[i - 1] + std::hypot(b.x - a.x, b.y - a.y);
     }
-    lastS_        = 0;
-    stopped_      = false;
-    stoppedSince_ = INVALID_TIMESTAMP;
+    lastS_             = 0;
+    lastCommandedSpeed_ = 0;
+    stopped_           = false;
+    stoppedSince_      = INVALID_TIMESTAMP;
 }
 
 void TrajectoryFollower::reset()
 {
     traj_.clear();
     cumS_.clear();
-    lastS_        = 0;
-    stopped_      = false;
-    stoppedSince_ = INVALID_TIMESTAMP;
+    lastS_             = 0;
+    lastCommandedSpeed_ = 0;
+    stopped_           = false;
+    stoppedSince_      = INVALID_TIMESTAMP;
 }
 
 void TrajectoryFollower::setRobotShape(const RobotShape& shape)
@@ -406,8 +408,12 @@ TrajectoryFollower::Output TrajectoryFollower::step(
                      ? FollowerStatus::OffPathExceeded
                      : FollowerStatus::Running;
 
-    double predV = odo.valid ? odo.odometryVelocityLocal.vx : 0.0;
-    predV        = std::max(0.0, predV);
+    // Seed the speed ramp from the follower's own last commanded speed (a
+    // feedforward integrator), not the measured odometry velocity: the profile
+    // must keep accelerating even when the odometry source reports no forward
+    // twist. Safety is handled by the predictive-safety scale and the node
+    // watchdog, not by throttling the ramp to measured velocity.
+    double predV = std::max(0.0, lastCommandedSpeed_);
 
     // Predictive safety: sweep the footprint over the command forecast and the
     // reference path ahead, and scale the commanded speed toward a stop before
@@ -480,6 +486,8 @@ TrajectoryFollower::Output TrajectoryFollower::step(
         {
             out.target_speed    = cmd.v;
             out.lookahead_point = cmd.lookahead;
+            // Persist for the next cycle's feedforward ramp seed.
+            lastCommandedSpeed_ = cmd.v;
         }
 
         // Advance the forecast.

--- a/mrpt_path_planning/src/follow/algos/TrajectoryFollower.cpp
+++ b/mrpt_path_planning/src/follow/algos/TrajectoryFollower.cpp
@@ -4,9 +4,13 @@
  * See LICENSE for license information.
  * ------------------------------------------------------------------------- */
 
+#include <mpp/data/robot_shape_sampling.h>
 #include <mpp/follow/algos/TrajectoryFollower.h>
+#include <mrpt/core/Clock.h>
 #include <mrpt/math/wrap2pi.h>
 #include <mrpt/poses/CPose2D.h>
+#include <mrpt/poses/CPose3D.h>
+#include <mrpt/system/datetime.h>
 
 #include <algorithm>
 #include <cmath>
@@ -61,6 +65,14 @@ void TrajectoryFollower::Parameters::load_from_yaml(
     MCP_LOAD_OPT(c, horizon);
     MCP_LOAD_OPT(c, sample_period);
     MCP_LOAD_OPT(c, emit_frame);
+    MCP_LOAD_OPT(c, safety_margin);
+    MCP_LOAD_OPT(c, stop_distance);
+    MCP_LOAD_OPT(c, slow_distance);
+    MCP_LOAD_OPT(c, safety_horizon);
+    MCP_LOAD_OPT(c, reference_lookahead_dist);
+    MCP_LOAD_OPT(c, footprint_sample_resolution);
+    MCP_LOAD_OPT(c, resume_scale);
+    MCP_LOAD_OPT(c, block_timeout);
 }
 
 mrpt::containers::yaml TrajectoryFollower::Parameters::as_yaml() const
@@ -80,6 +92,14 @@ mrpt::containers::yaml TrajectoryFollower::Parameters::as_yaml() const
     MCP_SAVE(c, horizon);
     MCP_SAVE(c, sample_period);
     MCP_SAVE(c, emit_frame);
+    MCP_SAVE(c, safety_margin);
+    MCP_SAVE(c, stop_distance);
+    MCP_SAVE(c, slow_distance);
+    MCP_SAVE(c, safety_horizon);
+    MCP_SAVE(c, reference_lookahead_dist);
+    MCP_SAVE(c, footprint_sample_resolution);
+    MCP_SAVE(c, resume_scale);
+    MCP_SAVE(c, block_timeout);
     return c;
 }
 
@@ -102,14 +122,37 @@ void TrajectoryFollower::setTrajectory(const Trajectory& traj)
         const auto& b = traj_[i].pose;
         cumS_[i]      = cumS_[i - 1] + std::hypot(b.x - a.x, b.y - a.y);
     }
-    lastS_ = 0;
+    lastS_        = 0;
+    stopped_      = false;
+    stoppedSince_ = INVALID_TIMESTAMP;
 }
 
 void TrajectoryFollower::reset()
 {
     traj_.clear();
     cumS_.clear();
-    lastS_ = 0;
+    lastS_        = 0;
+    stopped_      = false;
+    stoppedSince_ = INVALID_TIMESTAMP;
+}
+
+void TrajectoryFollower::setRobotShape(const RobotShape& shape)
+{
+    shapeSamples_ =
+        footprintSamplePoints(shape, params.footprint_sample_resolution);
+}
+
+void TrajectoryFollower::setObstacles(const mrpt::maps::CPointsMap& obstacles)
+{
+    obstacles_.clear();
+    obstacles_.insertAnotherMap(&obstacles, mrpt::poses::CPose3D::Identity());
+}
+
+void TrajectoryFollower::setObstacles(
+    const std::vector<mrpt::math::TPoint2D>& obstacles)
+{
+    obstacles_.clear();
+    for (const auto& p : obstacles) obstacles_.insertPoint(p.x, p.y);
 }
 
 // ------------------------------------------------------------------ geometry
@@ -174,6 +217,20 @@ mrpt::math::TPoint2D TrajectoryFollower::pointAtArc(double s) const
     return {a.x + t * (b.x - a.x), a.y + t * (b.y - a.y)};
 }
 
+mrpt::math::TPose2D TrajectoryFollower::poseAtArc(double s) const
+{
+    if (traj_.empty()) return {0, 0, 0};
+    s             = std::clamp(s, 0.0, totalLength());
+    std::size_t i = 0;
+    while (i + 2 < traj_.size() && cumS_[i + 1] < s) i++;
+    const auto&  a       = traj_[i].pose;
+    const auto&  b       = traj_[i + 1].pose;
+    const double segLen  = cumS_[i + 1] - cumS_[i];
+    const double t       = segLen > 1e-9 ? (s - cumS_[i]) / segLen : 0.0;
+    const double heading = std::atan2(b.y - a.y, b.x - a.x);
+    return {a.x + t * (b.x - a.x), a.y + t * (b.y - a.y), heading};
+}
+
 double TrajectoryFollower::speedCapAt(double s) const
 {
     if (traj_.empty()) return params.max_speed;
@@ -192,7 +249,7 @@ double TrajectoryFollower::speedCapAt(double s) const
 // ------------------------------------------------------------------- pursuit
 TrajectoryFollower::Command TrajectoryFollower::pursuit(
     const mrpt::math::TPose2D& fromPose, double currentV, double sHint,
-    double dt) const
+    double dt, double speedScale) const
 {
     Command          out;
     const Projection proj = projectToPath({fromPose.x, fromPose.y}, sHint);
@@ -221,6 +278,10 @@ TrajectoryFollower::Command TrajectoryFollower::pursuit(
             std::min(cap, std::sqrt(params.max_lateral_accel / std::abs(curv)));
     cap = std::min(cap, std::sqrt(2.0 * params.max_decel * remaining));
 
+    // Predictive-safety speed scale (caps the target before rate-limiting so
+    // decel stays bounded by max_decel).
+    cap *= std::clamp(speedScale, 0.0, 1.0);
+
     // Rate-limit the speed toward the cap.
     double v = std::clamp(
         cap, currentV - params.max_decel * dt,
@@ -230,6 +291,82 @@ TrajectoryFollower::Command TrajectoryFollower::pursuit(
     out.v     = v;
     out.omega = v * curv;
     return out;
+}
+
+// -------------------------------------------------------------------- safety
+double TrajectoryFollower::footprintClearance(
+    const mrpt::math::TPose2D& p) const
+{
+    if (obstacles_.empty()) return std::numeric_limits<double>::infinity();
+
+    const double c = std::cos(p.phi);
+    const double s = std::sin(p.phi);
+
+    // With no footprint set, fall back to the reference point only.
+    auto clearanceAt = [&](double lx, double ly) -> double
+    {
+        const double wx = p.x + lx * c - ly * s;
+        const double wy = p.y + lx * s + ly * c;
+        return std::sqrt(static_cast<double>(
+            obstacles_.kdTreeClosestPoint2DsqrError(wx, wy)));
+    };
+
+    if (shapeSamples_.empty()) return clearanceAt(0.0, 0.0);
+
+    double best = std::numeric_limits<double>::infinity();
+    for (const auto& v : shapeSamples_)
+        best = std::min(best, clearanceAt(v.x, v.y));
+    return best;
+}
+
+double TrajectoryFollower::forecastContactDistance(
+    const mrpt::math::TPose2D& startPose, double startV, double startS) const
+{
+    double              L = 0;
+    mrpt::math::TPose2D p = startPose;
+    double              v = std::max(0.0, startV);
+    double              s = startS;
+
+    const int nSteps = std::max(
+        1, static_cast<int>(
+               std::ceil(params.safety_horizon / params.sample_period)));
+
+    for (int k = 0; k <= nSteps; k++)
+    {
+        if (footprintClearance(p) <= params.safety_margin) return L;
+
+        const Command cmd = pursuit(p, v, s, params.sample_period, 1.0);
+        const mrpt::math::TPose2D pNext =
+            integrateUnicycle(p, cmd.v, cmd.omega, params.sample_period);
+
+        L += std::hypot(pNext.x - p.x, pNext.y - p.y);
+        p = pNext;
+        v = cmd.v;
+        s = projectToPath({p.x, p.y}, s).s;
+
+        if (totalLength() - s <= params.goal_dist_tol) break;
+    }
+    return std::numeric_limits<double>::infinity();
+}
+
+double TrajectoryFollower::referenceContactDistance(double startS) const
+{
+    const double step = std::max(0.02, params.footprint_sample_resolution);
+    for (double ds = 0; ds <= params.reference_lookahead_dist; ds += step)
+    {
+        const double s = startS + ds;
+        if (s > totalLength()) break;
+        if (footprintClearance(poseAtArc(s)) <= params.safety_margin) return ds;
+    }
+    return std::numeric_limits<double>::infinity();
+}
+
+double TrajectoryFollower::contactDistanceToScale(double d) const
+{
+    if (!std::isfinite(d)) return 1.0;
+    const double span =
+        std::max(1e-3, params.slow_distance - params.stop_distance);
+    return std::clamp((d - params.stop_distance) / span, 0.0, 1.0);
 }
 
 // ---------------------------------------------------------------------- step
@@ -269,14 +406,53 @@ TrajectoryFollower::Output TrajectoryFollower::step(
                      ? FollowerStatus::OffPathExceeded
                      : FollowerStatus::Running;
 
+    double predV = odo.valid ? odo.odometryVelocityLocal.vx : 0.0;
+    predV        = std::max(0.0, predV);
+
+    // Predictive safety: sweep the footprint over the command forecast and the
+    // reference path ahead, and scale the commanded speed toward a stop before
+    // contact. A hysteresis latch avoids chattering; a sustained stop reports
+    // Blocked. Inert when no obstacles/footprint are set.
+    double scale = 1.0;
+    if (!obstacles_.empty())
+    {
+        const double dFwd = forecastContactDistance(loc.pose, predV, proj.s);
+        const double dRef = referenceContactDistance(proj.s);
+        scale             = std::min(
+                        contactDistanceToScale(dFwd), contactDistanceToScale(dRef));
+    }
+
+    const auto nowStamp =
+        loc.timestamp != INVALID_TIMESTAMP ? loc.timestamp : mrpt::Clock::now();
+    if (stopped_)
+    {
+        if (scale >= params.resume_scale)
+        {
+            stopped_      = false;
+            stoppedSince_ = INVALID_TIMESTAMP;
+        }
+        else
+            scale = 0.0;
+    }
+    if (!stopped_ && scale <= 1e-3)
+    {
+        stopped_      = true;
+        stoppedSince_ = nowStamp;
+    }
+    if (stopped_ && out.status != FollowerStatus::OffPathExceeded &&
+        stoppedSince_ != INVALID_TIMESTAMP &&
+        mrpt::system::timeDifference(stoppedSince_, nowStamp) >=
+            params.block_timeout)
+        out.status = FollowerStatus::Blocked;
+
+    out.safety_scale = scale;
+
     // map->odom correction so the emitted chunk is smooth despite
     // relocalization.
     const mrpt::poses::CPose2D map2odom =
         mrpt::poses::CPose2D(odo.odometry) +
         (mrpt::poses::CPose2D() - mrpt::poses::CPose2D(loc.pose));
 
-    double predV = odo.valid ? odo.odometryVelocityLocal.vx : 0.0;
-    predV        = std::max(0.0, predV);
     mrpt::math::TPose2D predPose = loc.pose;
     double              predS    = proj.s;
 
@@ -289,7 +465,7 @@ TrajectoryFollower::Output TrajectoryFollower::step(
     for (int k = 0; k <= nSamples; k++)
     {
         const Command cmd =
-            pursuit(predPose, predV, predS, params.sample_period);
+            pursuit(predPose, predV, predS, params.sample_period, scale);
 
         TrajSample smp;
         smp.t = k * params.sample_period;
@@ -297,7 +473,7 @@ TrajectoryFollower::Output TrajectoryFollower::step(
             map2odom + mrpt::poses::CPose2D(predPose);
         smp.pose        = poseOdom.asTPose();
         smp.twist       = {cmd.v, 0.0, cmd.omega};
-        smp.speed_scale = 1.0;  // no safety scaling in the pursuit core yet
+        smp.speed_scale = scale;
         out.command.points.push_back(smp);
 
         if (k == 0)

--- a/mrpt_path_planning/src/follow/algos/TrajectoryFollower.cpp
+++ b/mrpt_path_planning/src/follow/algos/TrajectoryFollower.cpp
@@ -1,0 +1,319 @@
+/* -------------------------------------------------------------------------
+ *   SelfDriving C++ library based on PTGs and mrpt-nav
+ * Copyright (C) 2019-2026 Jose Luis Blanco, University of Almeria
+ * See LICENSE for license information.
+ * ------------------------------------------------------------------------- */
+
+#include <mpp/follow/algos/TrajectoryFollower.h>
+#include <mrpt/math/wrap2pi.h>
+#include <mrpt/poses/CPose2D.h>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+using namespace mpp;
+
+namespace
+{
+// Exact constant-(v,w) unicycle integration over dt.
+mrpt::math::TPose2D integrateUnicycle(
+    const mrpt::math::TPose2D& p, double v, double w, double dt)
+{
+    double x = p.x, y = p.y, phi = p.phi;
+    if (std::abs(w) < 1e-6)
+    {
+        x += v * dt * std::cos(phi);
+        y += v * dt * std::sin(phi);
+    }
+    else
+    {
+        const double dphi = w * dt;
+        const double R    = v / w;
+        x += R * (std::sin(phi + dphi) - std::sin(phi));
+        y += -R * (std::cos(phi + dphi) - std::cos(phi));
+        phi += dphi;
+    }
+    return {x, y, mrpt::math::wrapToPi(phi)};
+}
+}  // namespace
+
+TrajectoryFollower::TrajectoryFollower()
+    : mrpt::system::COutputLogger("TrajectoryFollower")
+{
+}
+
+// ---------------------------------------------------------------- Parameters
+void TrajectoryFollower::Parameters::load_from_yaml(
+    const mrpt::containers::yaml& c)
+{
+    MCP_LOAD_OPT(c, max_speed);
+    MCP_LOAD_OPT(c, max_accel);
+    MCP_LOAD_OPT(c, max_decel);
+    MCP_LOAD_OPT(c, max_lateral_accel);
+    MCP_LOAD_OPT(c, lookahead_min);
+    MCP_LOAD_OPT(c, lookahead_max);
+    MCP_LOAD_OPT(c, lookahead_time);
+    MCP_LOAD_OPT(c, goal_dist_tol);
+    MCP_LOAD_OPT_DEG(c, goal_ang_tol);
+    MCP_LOAD_OPT(c, max_cross_track);
+    MCP_LOAD_OPT(c, control_period);
+    MCP_LOAD_OPT(c, horizon);
+    MCP_LOAD_OPT(c, sample_period);
+    MCP_LOAD_OPT(c, emit_frame);
+}
+
+mrpt::containers::yaml TrajectoryFollower::Parameters::as_yaml() const
+{
+    mrpt::containers::yaml c = mrpt::containers::yaml::Map();
+    MCP_SAVE(c, max_speed);
+    MCP_SAVE(c, max_accel);
+    MCP_SAVE(c, max_decel);
+    MCP_SAVE(c, max_lateral_accel);
+    MCP_SAVE(c, lookahead_min);
+    MCP_SAVE(c, lookahead_max);
+    MCP_SAVE(c, lookahead_time);
+    MCP_SAVE(c, goal_dist_tol);
+    MCP_SAVE_DEG(c, goal_ang_tol);
+    MCP_SAVE(c, max_cross_track);
+    MCP_SAVE(c, control_period);
+    MCP_SAVE(c, horizon);
+    MCP_SAVE(c, sample_period);
+    MCP_SAVE(c, emit_frame);
+    return c;
+}
+
+TrajectoryFollower::Parameters TrajectoryFollower::Parameters::FromYAML(
+    const mrpt::containers::yaml& c)
+{
+    Parameters p;
+    p.load_from_yaml(c);
+    return p;
+}
+
+// ---------------------------------------------------------------- trajectory
+void TrajectoryFollower::setTrajectory(const Trajectory& traj)
+{
+    traj_ = traj;
+    cumS_.assign(traj_.size(), 0.0);
+    for (std::size_t i = 1; i < traj_.size(); i++)
+    {
+        const auto& a = traj_[i - 1].pose;
+        const auto& b = traj_[i].pose;
+        cumS_[i]      = cumS_[i - 1] + std::hypot(b.x - a.x, b.y - a.y);
+    }
+    lastS_ = 0;
+}
+
+void TrajectoryFollower::reset()
+{
+    traj_.clear();
+    cumS_.clear();
+    lastS_ = 0;
+}
+
+// ------------------------------------------------------------------ geometry
+TrajectoryFollower::Projection TrajectoryFollower::projectToPath(
+    const mrpt::math::TPoint2D& xy, double sHint) const
+{
+    Projection best;
+    double     bestD2 = std::numeric_limits<double>::infinity();
+
+    const double backWindow = 0.5;
+    const double fwdWindow  = std::max(3.0, 2.0 * params.lookahead_max);
+
+    // Two passes: a local window around sHint (keeps progress monotone on paths
+    // that re-approach themselves), then a full search if nothing matched.
+    for (int pass = 0; pass < 2 && !std::isfinite(bestD2); pass++)
+    {
+        const bool windowed = (pass == 0);
+        for (std::size_t i = 0; i + 1 < traj_.size(); i++)
+        {
+            if (windowed && (cumS_[i + 1] < sHint - backWindow ||
+                             cumS_[i] > sHint + fwdWindow))
+                continue;
+
+            const auto&  a    = traj_[i].pose;
+            const auto&  b    = traj_[i + 1].pose;
+            const double sx   = b.x - a.x;
+            const double sy   = b.y - a.y;
+            const double len2 = sx * sx + sy * sy;
+            if (len2 < 1e-9) continue;
+
+            double t        = ((xy.x - a.x) * sx + (xy.y - a.y) * sy) / len2;
+            t               = std::clamp(t, 0.0, 1.0);
+            const double px = a.x + t * sx;
+            const double py = a.y + t * sy;
+            const double d2 =
+                (xy.x - px) * (xy.x - px) + (xy.y - py) * (xy.y - py);
+            if (d2 < bestD2)
+            {
+                bestD2             = d2;
+                best.s             = cumS_[i] + t * std::sqrt(len2);
+                best.path_heading  = std::atan2(sy, sx);
+                const double cross = sx * (xy.y - a.y) - sy * (xy.x - a.x);
+                best.cross_track   = (cross >= 0 ? 1.0 : -1.0) * std::sqrt(d2);
+            }
+        }
+    }
+    if (!std::isfinite(bestD2)) best.s = sHint;
+    return best;
+}
+
+mrpt::math::TPoint2D TrajectoryFollower::pointAtArc(double s) const
+{
+    if (traj_.empty()) return {0, 0};
+    s = std::clamp(s, 0.0, totalLength());
+    // find segment [i, i+1] containing s
+    std::size_t i = 0;
+    while (i + 2 < traj_.size() && cumS_[i + 1] < s) i++;
+    const auto&  a      = traj_[i].pose;
+    const auto&  b      = traj_[i + 1].pose;
+    const double segLen = cumS_[i + 1] - cumS_[i];
+    const double t      = segLen > 1e-9 ? (s - cumS_[i]) / segLen : 0.0;
+    return {a.x + t * (b.x - a.x), a.y + t * (b.y - a.y)};
+}
+
+double TrajectoryFollower::speedCapAt(double s) const
+{
+    if (traj_.empty()) return params.max_speed;
+    s             = std::clamp(s, 0.0, totalLength());
+    std::size_t i = 0;
+    while (i + 2 < traj_.size() && cumS_[i + 1] < s) i++;
+    const double segLen = cumS_[i + 1] - cumS_[i];
+    const double t      = segLen > 1e-9 ? (s - cumS_[i]) / segLen : 0.0;
+    auto         eff = [&](double v) { return v <= 0 ? params.max_speed : v; };
+    const double v0  = eff(traj_[i].target_speed);
+    const double v1  = eff(traj_[i + 1].target_speed);
+    const double cap = v0 + t * (v1 - v0);
+    return std::min(cap, params.max_speed);
+}
+
+// ------------------------------------------------------------------- pursuit
+TrajectoryFollower::Command TrajectoryFollower::pursuit(
+    const mrpt::math::TPose2D& fromPose, double currentV, double sHint,
+    double dt) const
+{
+    Command          out;
+    const Projection proj = projectToPath({fromPose.x, fromPose.y}, sHint);
+
+    const double L = std::clamp(
+        params.lookahead_time * currentV, params.lookahead_min,
+        params.lookahead_max);
+    out.lookahead = pointAtArc(proj.s + L);
+
+    // Lookahead in robot frame.
+    const double dx = out.lookahead.x - fromPose.x;
+    const double dy = out.lookahead.y - fromPose.y;
+    const double c  = std::cos(fromPose.phi);
+    const double sn = std::sin(fromPose.phi);
+    const double xr = c * dx + sn * dy;
+    const double yr = -sn * dx + c * dy;
+    const double Ld = std::hypot(xr, yr);
+
+    const double curv = Ld > 1e-3 ? 2.0 * yr / (Ld * Ld) : 0.0;
+
+    // Speed caps: profile, curvature (lateral accel), and decel-to-goal.
+    const double remaining = std::max(0.0, totalLength() - proj.s);
+    double       cap       = speedCapAt(proj.s);
+    if (std::abs(curv) > 1e-3)
+        cap =
+            std::min(cap, std::sqrt(params.max_lateral_accel / std::abs(curv)));
+    cap = std::min(cap, std::sqrt(2.0 * params.max_decel * remaining));
+
+    // Rate-limit the speed toward the cap.
+    double v = std::clamp(
+        cap, currentV - params.max_decel * dt,
+        currentV + params.max_accel * dt);
+    v = std::max(0.0, v);
+
+    out.v     = v;
+    out.omega = v * curv;
+    return out;
+}
+
+// ---------------------------------------------------------------------- step
+TrajectoryFollower::Output TrajectoryFollower::step(
+    const VehicleLocalizationState& loc, const VehicleOdometryState& odo)
+{
+    Output out;
+    if (!hasTrajectory())
+    {
+        out.status = FollowerStatus::Idle;
+        return out;
+    }
+
+    const Projection proj = projectToPath({loc.pose.x, loc.pose.y}, lastS_);
+    lastS_                = proj.s;
+
+    // Heading at the path end (last segment direction).
+    const auto&  pEndA      = traj_[traj_.size() - 2].pose;
+    const auto&  pEndB      = traj_.back().pose;
+    const double endHeading = std::atan2(pEndB.y - pEndA.y, pEndB.x - pEndA.x);
+
+    out.arc_length_s    = proj.s;
+    out.cross_track_err = proj.cross_track;
+    out.heading_err     = mrpt::math::wrapToPi(loc.pose.phi - endHeading);
+
+    const double remaining = totalLength() - proj.s;
+
+    // Goal reached?
+    if (remaining <= params.goal_dist_tol &&
+        std::abs(out.heading_err) <= params.goal_ang_tol)
+    {
+        out.status = FollowerStatus::ReachedGoal;
+        return out;  // empty command => node stops
+    }
+
+    out.status = std::abs(proj.cross_track) > params.max_cross_track
+                     ? FollowerStatus::OffPathExceeded
+                     : FollowerStatus::Running;
+
+    // map->odom correction so the emitted chunk is smooth despite
+    // relocalization.
+    const mrpt::poses::CPose2D map2odom =
+        mrpt::poses::CPose2D(odo.odometry) +
+        (mrpt::poses::CPose2D() - mrpt::poses::CPose2D(loc.pose));
+
+    double predV = odo.valid ? odo.odometryVelocityLocal.vx : 0.0;
+    predV        = std::max(0.0, predV);
+    mrpt::math::TPose2D predPose = loc.pose;
+    double              predS    = proj.s;
+
+    out.command.frame_id = params.emit_frame;
+    out.command.stamp    = loc.timestamp;
+
+    const int nSamples = std::max(
+        1, static_cast<int>(std::ceil(params.horizon / params.sample_period)));
+
+    for (int k = 0; k <= nSamples; k++)
+    {
+        const Command cmd =
+            pursuit(predPose, predV, predS, params.sample_period);
+
+        TrajSample smp;
+        smp.t = k * params.sample_period;
+        const mrpt::poses::CPose2D poseOdom =
+            map2odom + mrpt::poses::CPose2D(predPose);
+        smp.pose        = poseOdom.asTPose();
+        smp.twist       = {cmd.v, 0.0, cmd.omega};
+        smp.speed_scale = 1.0;  // no safety scaling in the pursuit core yet
+        out.command.points.push_back(smp);
+
+        if (k == 0)
+        {
+            out.target_speed    = cmd.v;
+            out.lookahead_point = cmd.lookahead;
+        }
+
+        // Advance the forecast.
+        predPose =
+            integrateUnicycle(predPose, cmd.v, cmd.omega, params.sample_period);
+        predV = cmd.v;
+        predS = projectToPath({predPose.x, predPose.y}, predS).s;
+
+        if (totalLength() - predS <= params.goal_dist_tol) break;
+    }
+
+    return out;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,12 @@ selfdriving_add_test(
 )
 
 selfdriving_add_test(
+    TARGET  test_trajectory_follower
+    SOURCES test_trajectory_follower.cpp
+    LINK_LIBRARIES mrpt_path_planning GTest::GTest GTest::Main
+)
+
+selfdriving_add_test(
     TARGET  test_heuristic
     SOURCES test_heuristic.cpp
     LINK_LIBRARIES mrpt_path_planning GTest::GTest GTest::Main

--- a/tests/test_trajectory_follower.cpp
+++ b/tests/test_trajectory_follower.cpp
@@ -13,8 +13,10 @@
 
 #include <gtest/gtest.h>
 #include <mpp/follow/algos/TrajectoryFollower.h>
+#include <mrpt/core/Clock.h>
 #include <mrpt/math/wrap2pi.h>
 
+#include <chrono>
 #include <cmath>
 
 namespace
@@ -229,15 +231,127 @@ TEST(TrajectoryFollower, EmitsHorizonChunk)
         EXPECT_GT(out.command.points[i].t, out.command.points[i - 1].t);
 }
 
+// --------------------------- predictive safety ----------------------------
+
+TEST(TrajectoryFollower, SafetyInertWithoutObstacles)
+{
+    const std::vector<TPoint2D> pts = {{0, 0}, {5, 0}};
+    mpp::TrajectoryFollower     f;
+    f.setRobotShape(mpp::robot_radius_t{0.3});  // shape but no obstacles
+    f.setTrajectory(polyToTraj(pts, 0.5));
+
+    const auto r = simulate(f, {0, 0, 0}, pts);
+    EXPECT_TRUE(r.reached);  // safety layer does nothing without obstacles
+}
+
+TEST(TrajectoryFollower, StopsBeforeObstacle)
+{
+    const std::vector<TPoint2D> pts = {{0, 0}, {6, 0}};
+    mpp::TrajectoryFollower     f;
+    f.setRobotShape(mpp::robot_radius_t{0.3});
+    f.setObstacles(std::vector<TPoint2D>{{3.0, 0.0}});  // right on the path
+    f.setTrajectory(polyToTraj(pts, 0.5));
+
+    const auto r = simulate(f, {0, 0, 0}, pts);
+    EXPECT_FALSE(r.reached);  // must not drive through the obstacle
+    // Stops short of the obstacle (center + radius margin), but did advance.
+    EXPECT_GT(r.finalPose.x, 1.5);
+    EXPECT_LT(r.finalPose.x, 2.9);
+}
+
+TEST(TrajectoryFollower, ResumesAfterObstacleCleared)
+{
+    const std::vector<TPoint2D> pts = {{0, 0}, {6, 0}};
+    mpp::TrajectoryFollower     f;
+    f.setRobotShape(mpp::robot_radius_t{0.3});
+    f.setObstacles(std::vector<TPoint2D>{{3.0, 0.0}});
+    f.setTrajectory(polyToTraj(pts, 0.5));
+
+    // Phase 1: drive into the obstacle field until it stops.
+    TPose2D      robot = {0, 0, 0};
+    double       v     = 0;
+    const double dt    = f.params.control_period;
+    for (int k = 0; k < 2000; k++)
+    {
+        const auto out = f.step(mkLoc(robot), mkOdo(robot, v));
+        const auto tw  = out.command.points.front().twist;
+        robot          = integrate(robot, tw.vx, tw.omega, dt);
+        v              = tw.vx;
+        if (v < 1e-3 && robot.x > 1.0) break;  // stopped in front of obstacle
+    }
+    ASSERT_LT(v, 1e-2);
+    ASSERT_LT(robot.x, 2.9);
+
+    // Phase 2: obstacle removed -> must resume and reach the goal.
+    f.setObstacles(std::vector<TPoint2D>{});
+    bool reached = false;
+    for (int k = 0; k < 2000; k++)
+    {
+        const auto out = f.step(mkLoc(robot), mkOdo(robot, v));
+        if (out.status == mpp::FollowerStatus::ReachedGoal)
+        {
+            reached = true;
+            break;
+        }
+        const auto tw = out.command.points.front().twist;
+        robot         = integrate(robot, tw.vx, tw.omega, dt);
+        v             = tw.vx;
+    }
+    EXPECT_TRUE(reached);
+    EXPECT_NEAR(robot.x, 6.0, 0.2);
+}
+
+TEST(TrajectoryFollower, BlockedAfterTimeout)
+{
+    const std::vector<TPoint2D> pts = {{0, 0}, {6, 0}};
+    mpp::TrajectoryFollower     f;
+    f.params.block_timeout = 5.0;
+    f.setRobotShape(mpp::robot_radius_t{0.3});
+    f.setObstacles(std::vector<TPoint2D>{{3.0, 0.0}});
+    f.setTrajectory(polyToTraj(pts, 0.5));
+
+    const auto t0 = mrpt::Clock::now();
+
+    // Start already stopped in front of the obstacle.
+    auto loc      = mkLoc({2.6, 0, 0});
+    loc.timestamp = t0;
+    auto out      = f.step(loc, mkOdo({2.6, 0, 0}, 0));
+    EXPECT_EQ(out.safety_scale, 0.0);
+    EXPECT_NE(out.status, mpp::FollowerStatus::Blocked);  // just started
+
+    // Same obstacle, timestamp advanced past the block timeout.
+    loc.timestamp = t0 + std::chrono::milliseconds(6000);
+    out           = f.step(loc, mkOdo({2.6, 0, 0}, 0));
+    EXPECT_EQ(out.status, mpp::FollowerStatus::Blocked);
+}
+
+TEST(TrajectoryFollower, IgnoresObstacleOffPath)
+{
+    const std::vector<TPoint2D> pts = {{0, 0}, {6, 0}};
+    mpp::TrajectoryFollower     f;
+    f.setRobotShape(mpp::robot_radius_t{0.3});
+    // Obstacle well clear of the swept footprint corridor.
+    f.setObstacles(std::vector<TPoint2D>{{3.0, 2.0}});
+    f.setTrajectory(polyToTraj(pts, 0.5));
+
+    const auto r = simulate(f, {0, 0, 0}, pts);
+    EXPECT_TRUE(r.reached);
+    EXPECT_NEAR(r.finalPose.x, 6.0, 0.2);
+}
+
 TEST(TrajectoryFollower, ParamsYamlRoundTrip)
 {
     mpp::TrajectoryFollower::Parameters p;
     p.max_speed     = 0.33;
     p.lookahead_max = 2.0;
     p.horizon       = 2.5;
+    p.stop_distance = 0.42;
+    p.slow_distance = 1.75;
     const auto y    = p.as_yaml();
     const auto p2   = mpp::TrajectoryFollower::Parameters::FromYAML(y);
     EXPECT_NEAR(p2.max_speed, 0.33, 1e-9);
     EXPECT_NEAR(p2.lookahead_max, 2.0, 1e-9);
     EXPECT_NEAR(p2.horizon, 2.5, 1e-9);
+    EXPECT_NEAR(p2.stop_distance, 0.42, 1e-9);
+    EXPECT_NEAR(p2.slow_distance, 1.75, 1e-9);
 }

--- a/tests/test_trajectory_follower.cpp
+++ b/tests/test_trajectory_follower.cpp
@@ -1,0 +1,243 @@
+/* -------------------------------------------------------------------------
+ *   SelfDriving C++ library based on PTGs and mrpt-nav
+ * Copyright (C) 2019-2026 Jose Luis Blanco, University of Almeria
+ * See LICENSE for license information.
+ * ------------------------------------------------------------------------- */
+
+/**
+ * Unit tests for the pure-pursuit TrajectoryFollower core (no safety yet).
+ * Each test closes the loop with a trivial unicycle sim: feed the follower the
+ * robot pose as both localization (map) and odometry (identity map->odom),
+ * execute the immediate command twist for one control period, repeat.
+ */
+
+#include <gtest/gtest.h>
+#include <mpp/follow/algos/TrajectoryFollower.h>
+#include <mrpt/math/wrap2pi.h>
+
+#include <cmath>
+
+namespace
+{
+using mrpt::math::TPoint2D;
+using mrpt::math::TPose2D;
+
+mrpt::math::TPose2D integrate(const TPose2D& p, double v, double w, double dt)
+{
+    double x = p.x, y = p.y, phi = p.phi;
+    if (std::abs(w) < 1e-6)
+    {
+        x += v * dt * std::cos(phi);
+        y += v * dt * std::sin(phi);
+    }
+    else
+    {
+        const double dphi = w * dt;
+        const double R    = v / w;
+        x += R * (std::sin(phi + dphi) - std::sin(phi));
+        y += -R * (std::cos(phi + dphi) - std::cos(phi));
+        phi += dphi;
+    }
+    return {x, y, mrpt::math::wrapToPi(phi)};
+}
+
+double distToPolyline(const std::vector<TPoint2D>& pts, const TPoint2D& q)
+{
+    double best = std::numeric_limits<double>::infinity();
+    for (std::size_t i = 0; i + 1 < pts.size(); i++)
+    {
+        const auto&  a  = pts[i];
+        const auto&  b  = pts[i + 1];
+        const double sx = b.x - a.x, sy = b.y - a.y;
+        const double len2 = sx * sx + sy * sy;
+        double       t =
+            len2 > 1e-9 ? ((q.x - a.x) * sx + (q.y - a.y) * sy) / len2 : 0;
+        t               = std::clamp(t, 0.0, 1.0);
+        const double px = a.x + t * sx, py = a.y + t * sy;
+        best = std::min(best, std::hypot(q.x - px, q.y - py));
+    }
+    return best;
+}
+
+mpp::Trajectory polyToTraj(const std::vector<TPoint2D>& pts, double speed)
+{
+    mpp::Trajectory tr;
+    for (std::size_t i = 0; i < pts.size(); i++)
+    {
+        double heading = 0;
+        if (i + 1 < pts.size())
+            heading =
+                std::atan2(pts[i + 1].y - pts[i].y, pts[i + 1].x - pts[i].x);
+        else if (i > 0)
+            heading =
+                std::atan2(pts[i].y - pts[i - 1].y, pts[i].x - pts[i - 1].x);
+        tr.emplace_back(TPose2D(pts[i].x, pts[i].y, heading), speed);
+    }
+    return tr;
+}
+
+mpp::VehicleLocalizationState mkLoc(const TPose2D& p)
+{
+    mpp::VehicleLocalizationState s;
+    s.valid = true;
+    s.pose  = p;
+    return s;
+}
+mpp::VehicleOdometryState mkOdo(const TPose2D& p, double v)
+{
+    mpp::VehicleOdometryState s;
+    s.valid                 = true;
+    s.odometry              = p;  // identity map->odom in these tests
+    s.odometryVelocityLocal = mrpt::math::TTwist2D(v, 0, 0);
+    return s;
+}
+
+struct SimResult
+{
+    bool                reached  = false;
+    double              maxCross = 0;
+    double              maxSpeed = 0;
+    TPose2D             finalPose;
+    int                 steps      = 0;
+    mpp::FollowerStatus lastStatus = mpp::FollowerStatus::Idle;
+};
+
+SimResult simulate(
+    mpp::TrajectoryFollower& f, const TPose2D& start,
+    const std::vector<TPoint2D>& pathPts, int maxSteps = 2000)
+{
+    SimResult    r;
+    TPose2D      robot = start;
+    double       v     = 0;
+    const double dt    = f.params.control_period;
+    for (int k = 0; k < maxSteps; k++)
+    {
+        const auto out = f.step(mkLoc(robot), mkOdo(robot, v));
+        r.lastStatus   = out.status;
+        r.maxCross =
+            std::max(r.maxCross, distToPolyline(pathPts, {robot.x, robot.y}));
+        r.finalPose = robot;
+        r.steps     = k;
+        if (out.status == mpp::FollowerStatus::ReachedGoal)
+        {
+            r.reached = true;
+            break;
+        }
+        if (out.command.points.empty()) break;
+        const auto tw = out.command.points.front().twist;
+        r.maxSpeed    = std::max(r.maxSpeed, tw.vx);
+        robot         = integrate(robot, tw.vx, tw.omega, dt);
+        v             = tw.vx;
+    }
+    return r;
+}
+}  // namespace
+
+// ---------------------------------------------------------------------------
+
+TEST(TrajectoryFollower, IdleWithoutTrajectory)
+{
+    mpp::TrajectoryFollower f;
+    const auto              out = f.step(mkLoc({0, 0, 0}), mkOdo({0, 0, 0}, 0));
+    EXPECT_EQ(out.status, mpp::FollowerStatus::Idle);
+    EXPECT_TRUE(out.command.empty());
+}
+
+TEST(TrajectoryFollower, StraightLineOnPath)
+{
+    const std::vector<TPoint2D> pts = {{0, 0}, {5, 0}};
+    mpp::TrajectoryFollower     f;
+    f.setTrajectory(polyToTraj(pts, 0.5));
+
+    const auto r = simulate(f, {0, 0, 0}, pts);
+    EXPECT_TRUE(r.reached);
+    EXPECT_LT(r.maxCross, 0.05);
+    EXPECT_NEAR(r.finalPose.x, 5.0, 0.2);
+    EXPECT_NEAR(r.finalPose.y, 0.0, 0.2);
+}
+
+TEST(TrajectoryFollower, ConvergesFromLateralOffset)
+{
+    const std::vector<TPoint2D> pts = {{0, 0}, {8, 0}};
+    mpp::TrajectoryFollower     f;
+    f.setTrajectory(polyToTraj(pts, 0.5));
+
+    // Start 0.5 m off the line, facing along it.
+    const auto r = simulate(f, {0, 0.5, 0}, pts);
+    EXPECT_TRUE(r.reached);
+    // It must actually rejoin: end essentially on the line.
+    EXPECT_LT(distToPolyline(pts, {r.finalPose.x, r.finalPose.y}), 0.1);
+    // And never diverge worse than the initial offset.
+    EXPECT_LT(r.maxCross, 0.6);
+}
+
+TEST(TrajectoryFollower, FollowsCornerPath)
+{
+    const std::vector<TPoint2D> pts = {{0, 0}, {4, 0}, {4, 4}};
+    mpp::TrajectoryFollower     f;
+    f.params.max_speed = 0.4;
+    f.setTrajectory(polyToTraj(pts, 0.4));
+
+    const auto r = simulate(f, {0, 0, 0}, pts);
+    EXPECT_TRUE(r.reached);
+    EXPECT_LT(r.maxCross, 0.7);  // cuts the corner but stays bounded
+    EXPECT_NEAR(r.finalPose.x, 4.0, 0.3);
+    EXPECT_NEAR(r.finalPose.y, 4.0, 0.3);
+}
+
+TEST(TrajectoryFollower, RespectsSpeedCap)
+{
+    const std::vector<TPoint2D> pts = {{0, 0}, {6, 0}};
+    mpp::TrajectoryFollower     f;
+    f.params.max_speed = 1.0;
+    f.setTrajectory(
+        polyToTraj(pts, 0.2));  // per-point cap well below max_speed
+
+    const auto r = simulate(f, {0, 0, 0}, pts);
+    EXPECT_TRUE(r.reached);
+    EXPECT_LE(r.maxSpeed, 0.2 + 1e-3);
+}
+
+TEST(TrajectoryFollower, OffPathExceeded)
+{
+    const std::vector<TPoint2D> pts = {{0, 0}, {5, 0}};
+    mpp::TrajectoryFollower     f;
+    f.params.max_cross_track = 1.0;
+    f.setTrajectory(polyToTraj(pts, 0.5));
+
+    // Start 2 m off the line -> beyond the cross-track limit on the first step.
+    const auto out = f.step(mkLoc({1, 2, 0}), mkOdo({1, 2, 0}, 0));
+    EXPECT_EQ(out.status, mpp::FollowerStatus::OffPathExceeded);
+    EXPECT_FALSE(out.command.empty());  // still tries to rejoin
+}
+
+TEST(TrajectoryFollower, EmitsHorizonChunk)
+{
+    const std::vector<TPoint2D> pts = {{0, 0}, {5, 0}};
+    mpp::TrajectoryFollower     f;
+    f.params.horizon       = 1.5;
+    f.params.sample_period = 0.1;
+    f.setTrajectory(polyToTraj(pts, 0.5));
+
+    const auto out = f.step(mkLoc({0, 0, 0}), mkOdo({0, 0, 0}, 0));
+    EXPECT_EQ(out.status, mpp::FollowerStatus::Running);
+    ASSERT_GE(out.command.points.size(), 2u);
+    EXPECT_EQ(out.command.frame_id, "odom");
+    EXPECT_NEAR(out.command.points.front().t, 0.0, 1e-9);
+    // strictly increasing time stamps
+    for (std::size_t i = 1; i < out.command.points.size(); i++)
+        EXPECT_GT(out.command.points[i].t, out.command.points[i - 1].t);
+}
+
+TEST(TrajectoryFollower, ParamsYamlRoundTrip)
+{
+    mpp::TrajectoryFollower::Parameters p;
+    p.max_speed     = 0.33;
+    p.lookahead_max = 2.0;
+    p.horizon       = 2.5;
+    const auto y    = p.as_yaml();
+    const auto p2   = mpp::TrajectoryFollower::Parameters::FromYAML(y);
+    EXPECT_NEAR(p2.max_speed, 0.33, 1e-9);
+    EXPECT_NEAR(p2.lookahead_max, 2.0, 1e-9);
+    EXPECT_NEAR(p2.horizon, 2.5, 1e-9);
+}


### PR DESCRIPTION
## Summary

Adds a new `mpp::TrajectoryFollower` (pure-pursuit core + arc-length speed profile + predictive safety), plus a fix to the feedforward speed ramp uncovered by closed-loop simulation.

The branch history:
- `TrajectoryFollower` pursuit core + trajectory-serving interface
- explicit library source list (no `GLOB_RECURSE`)
- predictive safety layer (footprint sweep, kd-tree clearance, hysteresis stop/resume, `Blocked` after timeout)
- **this PR's tip:** seed the speed ramp from the follower's own last commanded speed instead of the measured odometry velocity

## The ramp fix

The feedforward speed ramp was rate-limited from the measured odometry velocity, so the profile never accelerated when the odometry source reports pose but a zero twist (common with some simulators/odometry sources). It now rate-limits from the follower's own last commanded speed (a feedforward integrator). Safety is still enforced by the predictive-safety scale and the node watchdog, not by throttling the ramp to measured velocity. `lastCommandedSpeed_` is reset in `setTrajectory()`/`reset()`.

## Testing

All existing unit tests pass. Validated end-to-end in a closed-loop mvsim benchmark (tutabot Ackermann robot): a "clear" scenario tracks a 12 m path past off-path obstacles (cross-track RMS ~4.7 cm, no false stop) and a "blocked" scenario stops short of an on-path box with no collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DoHDcrWfHk6WWRoHxgUC7Q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added trajectory-following capabilities with pure-pursuit control, speed limits, goal detection, and off-path status reporting.
  * Added predictive obstacle safety, automatic slowing/stopping, and controlled resumption.
  * Added support for robot footprint sampling and sampled trajectory commands.
  * Added a vehicle interface with emergency stops and watchdog protection.
  * Added YAML configuration support for follower parameters.

* **Tests**
  * Added comprehensive coverage for path following, speed control, safety behavior, trajectory sampling, and configuration round-tripping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->